### PR TITLE
fix: ensure query is prepared by listening to `changes` stream

### DIFF
--- a/packages/cbl/lib/src/query/ffi_query.dart
+++ b/packages/cbl/lib/src/query/ffi_query.dart
@@ -43,6 +43,8 @@ class FfiQuery extends QueryBase
           definition: definition,
         );
 
+  var _isPrepared = false;
+
   late final _listenerTokens = ListenerTokenRegistry(this);
 
   @override
@@ -130,10 +132,20 @@ class FfiQuery extends QueryBase
       ));
 
   @override
-  void prepare() => super.prepare();
+  T useSync<T>(T Function() f) => super.useSync(() {
+        prepare();
+        return f();
+      });
 
-  @override
-  FutureOr<void> performPrepare() {
+  void prepare() {
+    if (_isPrepared) {
+      return;
+    }
+    _isPrepared = true;
+    _performPrepare();
+  }
+
+  void _performPrepare() {
     native = CBLObject(
       database!.native.call((pointer) => _bindings.create(
             pointer,

--- a/packages/cbl/lib/src/query/ffi_query.dart
+++ b/packages/cbl/lib/src/query/ffi_query.dart
@@ -142,6 +142,7 @@ class FfiQuery extends QueryBase
       return;
     }
     _isPrepared = true;
+    attachToParentResource();
     _performPrepare();
   }
 

--- a/packages/cbl/lib/src/query/proxy_query.dart
+++ b/packages/cbl/lib/src/query/proxy_query.dart
@@ -112,7 +112,10 @@ class ProxyQuery extends QueryBase with ProxyObjectMixin implements AsyncQuery {
         return f();
       });
 
-  Future<void> prepare() => _preparation ??= _performPrepare();
+  Future<void> prepare() {
+    attachToParentResource();
+    return _preparation ??= _performPrepare();
+  }
 
   Future<void> _performPrepare() async {
     final channel = database!.channel;

--- a/packages/cbl/lib/src/query/proxy_query.dart
+++ b/packages/cbl/lib/src/query/proxy_query.dart
@@ -34,6 +34,7 @@ class ProxyQuery extends QueryBase with ProxyObjectMixin implements AsyncQuery {
           definition: definition,
         );
 
+  Future<void>? _preparation;
   late final _lock = Lock();
   late final _listenerTokens = ListenerTokenRegistry(this);
   late List<String> _columnNames;
@@ -100,20 +101,20 @@ class ProxyQuery extends QueryBase with ProxyObjectMixin implements AsyncQuery {
       use(() => _listenerTokens.remove(token));
 
   @override
-  AsyncListenStream<QueryChange> changes() =>
-      // ignore: lines_longer_than_80_chars
-      // TODO(blaugold): refactor `QueryBase` so `changes` can be wrapped with `useSync`
-      ListenerStream(
+  AsyncListenStream<QueryChange> changes() => useSync(() => ListenerStream(
         parent: this,
-        addListener: _addChangeListener,
-      );
+        addListener: (listener) => use(() => _addChangeListener(listener)),
+      ));
 
   @override
-  // ignore: cast_nullable_to_non_nullable
-  Future<void> prepare() => super.prepare() as Future<void>;
+  Future<T> use<T>(FutureOr<T> Function() f) => super.use(() async {
+        await prepare();
+        return f();
+      });
 
-  @override
-  Future<void> performPrepare() async {
+  Future<void> prepare() => _preparation ??= _performPrepare();
+
+  Future<void> _performPrepare() async {
     final channel = database!.channel;
 
     final state = await channel.call(CreateQuery(

--- a/packages/cbl/lib/src/query/select.dart
+++ b/packages/cbl/lib/src/query/select.dart
@@ -88,9 +88,6 @@ class SelectImpl extends QueryBase with BuilderQueryMixin implements Select {
   Stream<QueryChange> changes() => useSync(() => throw UnimplementedError());
 
   @override
-  FutureOr<void> performPrepare() => throw UnimplementedError();
-
-  @override
   Future<void> performClose() => throw UnimplementedError();
 }
 

--- a/packages/cbl_e2e_tests/lib/src/query/query_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/query/query_test.dart
@@ -182,6 +182,19 @@ SELECT fl_result(fl_value(_.body, 'doc')) FROM kv_default AS _ WHERE (_.flags & 
       );
     });
 
+    apiTest('listen to change stream of query created by builder', () async {
+      // https://github.com/cbl-dart/cbl-dart/issues/225
+      final db = await openTestDatabase();
+      final query = const QueryBuilder()
+          .select(SelectResult.all())
+          .from(DataSource.database(db));
+
+      expect(
+        query.changes().asyncMap((change) => change.results.allResults()),
+        emitsInOrder(<Object>[isEmpty]),
+      );
+    });
+
     apiTest('bad query: error position highlighting', () async {
       final db = await openTestDatabase();
       expect(


### PR DESCRIPTION
Fixes #225