### PR TITLE
feat: add `cbl_dart` package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -302,3 +302,44 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           ./tools/ci-steps.sh uploadCoverageData "e2e.prebuilt"
+
+  test-cbl_dart:
+    name: cbl_dart unit tests
+    strategy:
+      matrix:
+        package: [cbl_dart]
+        dart: [stable]
+        embedder: [standalone]
+        os: [macOS, Ubuntu]
+    env:
+      EMBEDDER: ${{ matrix.embedder }}
+      TARGET_OS: ${{ matrix.os }}
+      TEST_PACKAGE: ${{ matrix.package }}
+    continue-on-error: ${{ matrix.dart != 'stable' }}
+    runs-on: >-
+      ${{ fromJSON('{ 
+        "macOS":"macos-11",
+        "Ubuntu":"ubuntu-20.04"
+      }')[matrix.os] }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ env[format('dart-version-{0}', matrix.dart)] }}
+
+      - name: Bootstrap Dart package
+        run: ./tools/ci-steps.sh bootstrapPackage --no-melos
+
+      - name: Run tests
+        working-directory: packages/${{ matrix.package }}
+        run: dart test --coverage coverage/dart
+
+      - name: Upload coverage data
+        if: ${{ matrix.dart == 'stable' }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          ./tools/ci-steps.sh uploadCoverageData "unit.${{ matrix.package }}"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ All Dart code is organized into several [packages].
 
 | Package                          | Description                                                                                                                                 | Pub                                                                                                   | Internal     |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------ |
-| [cbl]                            | Dart package for Couchbase Lite                                                                                                             | [![](https://badgen.net/pub/v/cbl)](https://pub.dev/packages/cbl)                                     |              |
+| [cbl]                            | Dart API Couchbase Lite                                                                                                                     | [![](https://badgen.net/pub/v/cbl)](https://pub.dev/packages/cbl)                                     |              |
+| [cbl_dart]                       | Package to use Couchbase Lite in pure Dart apps                                                                                             | [![](https://badgen.net/pub/v/cbl_dart)](https://pub.dev/packages/cbl_dart)                           |              |
 | [cbl_e2e_tests]                  | E2E tests                                                                                                                                   |                                                                                                       |              |
 | [cbl_e2e_tests_flutter]          | E2E tests runner for Flutter                                                                                                                |                                                                                                       |              |
 | [cbl_e2e_tests_standalone_dart]  | E2E tests runner for standalone Dart                                                                                                        |                                                                                                       |              |
@@ -48,6 +49,7 @@ Read [CONTRIBUTING] to get started developing.
 
 [packages]: https://github.com/cbl-dart/cbl-dart/tree/main/packages
 [cbl]: https://github.com/cbl-dart/cbl-dart/tree/main/packages/cbl
+[cbl_dart]: https://github.com/cbl-dart/cbl-dart/tree/main/packages/cbl_dart
 [cbl_e2e_tests]:
   https://github.com/cbl-dart/cbl-dart/tree/main/packages/cbl_e2e_tests
 [cbl_e2e_tests_standalone_dart]:

--- a/packages/cbl/README.md
+++ b/packages/cbl/README.md
@@ -19,7 +19,7 @@ native platforms which are supported by Dart.
 
 - [🤩 Features](#-features)
 - [⛔ Limitations](#-limitations)
-- [🔌 Getting started for Flutter](#-getting-started-for-flutter)
+- [🔌 Getting started](#-getting-started)
 - [🔑 Key concepts](#-key-concepts)
   - [Synchronous and Asynchronous APIs](#synchronous-and-asynchronous-apis)
   - [Change listeners](#change-listeners)
@@ -77,11 +77,14 @@ Lite are currently not supported:
 - Integration with system-wide configured proxies
 - VPN On Demand on iOS
 
-# 🔌 Getting started for Flutter
+# 🔌 Getting started
 
-Head over to the [Flutter plugin for Couchbase Lite
-(`cbl_flutter`)][cbl_flutter] to get started using Couchbase Lite in your
-Flutter app.
+To use Couchbase Lite in a
+
+- **Dart** app go to [`cbl_dart`][cbl_dart]
+- **Flutter** app go to [`cbl_flutter`][cbl_flutter]
+
+and follow the instructions for getting started.
 
 # 🔑 Key concepts
 
@@ -441,6 +444,7 @@ Read [CONTRIBUTING] to get started developing.
   https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/index.html
 [couchbase lite swift docs]:
   https://docs.couchbase.com/couchbase-lite/3.0/swift/quickstart.html
+[cbl_dart]: https://pub.dev/packages/cbl_dart
 [cbl_flutter]: https://pub.dev/packages/cbl_flutter
 [issues]: https://github.com/cbl-dart/cbl-dart/issues
 [sync gateway]: https://www.couchbase.com/sync-gateway

--- a/packages/cbl_dart/CHANGELOG.md
+++ b/packages/cbl_dart/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0-beta.0
+
+- Initial release.

--- a/packages/cbl_dart/LICENSE
+++ b/packages/cbl_dart/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2021] [Gabriel Terwesten]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/cbl_dart/README.md
+++ b/packages/cbl_dart/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/cbl-dart/cbl-dart/actions/workflows/ci.yaml/badge.svg)](https://github.com/cbl-dart/cbl-dart/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/cbl-dart/cbl-dart/branch/main/graph/badge.svg?token=XNUVBY3Y39)](https://codecov.io/gh/cbl-dart/cbl-dart)
 
-Couchbase Lite for pure Dart apps, such as servers and CLI tools.
+Couchbase Lite for pure Dart apps, such as servers and CLIs.
 
 The Couchbase Lite API is in the [`cbl`][cbl] package. This package is enabling
 the use of `cbl` in pure Dart apps.
@@ -40,9 +40,9 @@ the use of `cbl` in pure Dart apps.
    }
    ```
 
-   Note that `init` downloads the needed native libraries, if they have not
-   already been cached. See the documentation for `CouchbaseLiteDart.init` more
-   information.
+   Note that `init` downloads the needed native libraries if they have not
+   already been cached. See the documentation for `CouchbaseLiteDart.init` for
+   more information.
 
    > ⚖️ You need to comply with the Couchbase licensing terms of the edition of
    > Couchbase Lite you select.

--- a/packages/cbl_dart/README.md
+++ b/packages/cbl_dart/README.md
@@ -1,0 +1,66 @@
+[![Version](https://badgen.net/pub/v/cbl_dart)](https://pub.dev/packages/cbl_dart)
+[![License](https://badgen.net/pub/license/cbl_dart)](https://github.com/cbl-dart/cbl-dart/blob/main/packages/cbl_dart/LICENSE)
+[![CI](https://github.com/cbl-dart/cbl-dart/actions/workflows/ci.yaml/badge.svg)](https://github.com/cbl-dart/cbl-dart/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/cbl-dart/cbl-dart/branch/main/graph/badge.svg?token=XNUVBY3Y39)](https://codecov.io/gh/cbl-dart/cbl-dart)
+
+Couchbase Lite for pure Dart apps, such as servers and CLI tools.
+
+The Couchbase Lite API is in the [`cbl`][cbl] package. This package is enabling
+the use of `cbl` in pure Dart apps.
+
+> This package is in beta. Use it with caution and [report any issues you
+> see][issues].
+
+# 🎯 Platform Support
+
+| Platform | Version                | Note                   |
+| -------: | :--------------------- | ---------------------- |
+|    macOS | >= 10.14               |                        |
+|    Linux | == Ubuntu 20.04-x86_64 |                        |
+|  Windows | >= 10                  | 🚧 Not yet implemented |
+
+# 🔌 Getting Started
+
+1. Add [`cbl`][cbl] and `cbl_dart` as dependencies:
+
+   ```yaml
+   dependencies:
+     cbl: ...
+     cbl_dart: ...
+   ```
+
+1. Initialize Couchbase Lite before using it. This is also where you select the
+   edition of Couchbase Lite you want to use:
+
+   ```dart
+   import 'package:cbl_dart/cbl_dart.dart';
+
+   Future<void> initCouchbaseLite() async {
+     await CouchbaseLiteDart.init(edition: Edition.community);
+   }
+   ```
+
+   Note that `init` downloads the needed native libraries, if they have not
+   already been cached. See the documentation for `CouchbaseLiteDart.init` more
+   information.
+
+   > ⚖️ You need to comply with the Couchbase licensing terms of the edition of
+   > Couchbase Lite you select.
+
+# Default database directory
+
+When opening a database without specifying a directory, the current working
+directory will be used. `CouchbaseLiteDart.init` allows you to specify a
+different default directory.
+
+# 💡 Where to go next
+
+- Check out the example app in the **Example** tab.
+- Look at the usage examples for [`cbl`][cbl] (go to the latest prerelease).
+
+# ⚖️ Disclaimer
+
+> ⚠️ This is not an official Couchbase product.
+
+[cbl]: https://pub.dev/packages/cbl
+[issues]: https://github.com/cbl-dart/cbl-dart/issues

--- a/packages/cbl_dart/example/.gitignore
+++ b/packages/cbl_dart/example/.gitignore
@@ -1,0 +1,1 @@
+messages.cblite2

--- a/packages/cbl_dart/example/README.md
+++ b/packages/cbl_dart/example/README.md
@@ -1,0 +1,1 @@
+Example app which is demonstrating how to use `cbl_dart` in a simple CLI.

--- a/packages/cbl_dart/example/bin/cbl_dart_example.dart
+++ b/packages/cbl_dart/example/bin/cbl_dart_example.dart
@@ -1,0 +1,3 @@
+import 'package:cbl_dart_example/main.dart' as example;
+
+Future<void> main(List<String> args) => example.main(args);

--- a/packages/cbl_dart/example/bin/cbl_dart_example.dart
+++ b/packages/cbl_dart/example/bin/cbl_dart_example.dart
@@ -1,3 +1,0 @@
-import 'package:cbl_dart_example/main.dart' as example;
-
-Future<void> main(List<String> args) => example.main(args);

--- a/packages/cbl_dart/example/lib/main.dart
+++ b/packages/cbl_dart/example/lib/main.dart
@@ -8,8 +8,18 @@ import 'package:cbl_dart/cbl_dart.dart';
 late final Database db;
 
 Future<void> main(List<String> args) async {
-  if (args.isNotEmpty && args.length != 1) {
-    print('Usage: [message]');
+  if (args.contains('--help') ||
+      args.contains('-h') ||
+      (args.isNotEmpty && args.length != 1)) {
+    print(
+      '''
+Usage: dart lib/main.dart [message]
+
+The provided message will be stored in the database.
+
+If no message is provided, all stored messages will be listed.
+''',
+    );
     exit(1);
   }
 

--- a/packages/cbl_dart/example/lib/main.dart
+++ b/packages/cbl_dart/example/lib/main.dart
@@ -1,0 +1,65 @@
+// ignore_for_file: avoid_print
+
+import 'dart:io';
+
+import 'package:cbl/cbl.dart';
+import 'package:cbl_dart/cbl_dart.dart';
+
+late final Database db;
+
+Future<void> main(List<String> args) async {
+  if (args.isNotEmpty && args.length != 1) {
+    print('Usage: [message]');
+    exit(1);
+  }
+
+  await CouchbaseLiteDart.init(edition: Edition.community);
+
+  db = await Database.openAsync('messages');
+
+  final message = args.isEmpty ? null : args[0];
+
+  if (message != null) {
+    await storeMessage(message);
+  } else {
+    await listMessages();
+  }
+
+  await db.close();
+}
+
+Future<void> storeMessage(String message) async {
+  final doc = MutableDocument({
+    'type': 'message',
+    'createdAt': DateTime.now(),
+    'body': message,
+  });
+
+  await db.saveDocument(doc);
+
+  print('Message ${doc.id} stored: ${doc.toJson()}');
+}
+
+Future<void> listMessages() async {
+  final query = const QueryBuilder()
+      .select(
+        SelectResult.expression(Meta.id),
+        SelectResult.property('createdAt'),
+        SelectResult.property('body'),
+      )
+      .from(DataSource.database(db))
+      .where(Expression.property('type').equalTo(
+        Expression.string('message'),
+      ))
+      .orderBy(Ordering.property('createdAt').descending());
+
+  final resultSet = await query.execute();
+  var messages = 0;
+
+  await for (final result in resultSet.asStream()) {
+    messages++;
+    print(result.toJson());
+  }
+
+  print('$messages messages found');
+}

--- a/packages/cbl_dart/example/pubspec.yaml
+++ b/packages/cbl_dart/example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: cbl_dart_example
+publish_to: none
+
+executables:
+  cbl_dart_example:
+
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+
+dependencies:
+  cbl: ^1.0.0-beta.9
+  cbl_dart: ^1.0.0-beta.0

--- a/packages/cbl_dart/example/pubspec.yaml
+++ b/packages/cbl_dart/example/pubspec.yaml
@@ -1,9 +1,6 @@
 name: cbl_dart_example
 publish_to: none
 
-executables:
-  cbl_dart_example:
-
 environment:
   sdk: '>=2.12.0 <3.0.0'
 

--- a/packages/cbl_dart/lib/cbl_dart.dart
+++ b/packages/cbl_dart/lib/cbl_dart.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:cbl/cbl.dart';
+// ignore: implementation_imports
+import 'package:cbl/src/support/isolate.dart';
+
+import 'src/acquire_libraries.dart';
+import 'src/package.dart';
+
+export 'src/package.dart' show Edition;
+
+/// Initializes global resources and configures global settings, such as
+/// logging, for usage of Couchbase Lite in pure Dart apps.
+class CouchbaseLiteDart {
+  /// Private constructor to allow control over instance creation.
+  CouchbaseLiteDart._();
+
+  /// Initializes the `cbl` package, for the main isolate.
+  ///
+  /// If specified, [filesDir] is used to store files created by Couchbase Lite
+  /// by default. For example if a [Database] is opened or copied without
+  /// specifying a [DatabaseConfiguration.directory], a subdirectory in the
+  /// directory specified here will be used. If no [filesDir] directory is
+  /// provided, the working directory is used when opening and copying
+  /// databases.
+  ///
+  /// If the native libraries have not been downloaded yet, this method will
+  /// download them and store them in [nativeLibrariesDir]. If no directory is
+  /// provided, a system-wide default directory will be used.
+  /// [nativeLibrariesDir] should be within the directory where apps should
+  /// store cached data on the current platform.
+  static Future<void> init({
+    required Edition edition,
+    String? filesDir,
+    String? nativeLibrariesDir,
+  }) async {
+    final context = filesDir == null ? null : await _initContext(filesDir);
+
+    final libraries = await acquireLibraries(
+      edition: edition,
+      mergedNativeLibrariesDir: nativeLibrariesDir,
+    );
+
+    initMainIsolate(IsolateContext(initContext: context, libraries: libraries));
+
+    _setupLogging();
+  }
+}
+
+Future<InitContext> _initContext(String filesDir) async {
+  await Directory(filesDir).create(recursive: true);
+  return InitContext(filesDir: filesDir, tempDir: filesDir);
+}
+
+void _setupLogging() {
+  Database.log.console.level = LogLevel.warning;
+}

--- a/packages/cbl_dart/lib/src/acquire_libraries.dart
+++ b/packages/cbl_dart/lib/src/acquire_libraries.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:cbl/cbl.dart';
+import 'package:path/path.dart' as p;
+
+import 'install_libraries.dart';
+import 'package.dart';
+
+/// Ensures that the latest releases of the libraries are installed and
+/// returns the corresponding [Libraries] configuration.
+///
+/// See [Package.latestReleases] for the releases installed by this function.
+///
+/// [edition] is the edition of Couchbase Lite to install.
+///
+/// [mergedNativeLibrariesDir] is the directory where the native libraries will
+/// be installed. If not specified, the platform specific, system-wide default
+/// directory will be used.
+Future<Libraries> acquireLibraries({
+  required Edition edition,
+  String? mergedNativeLibrariesDir,
+}) async {
+  mergedNativeLibrariesDir ??= _sharedMergedNativesLibrariesDir();
+  await Directory(mergedNativeLibrariesDir).create(recursive: true);
+
+  final packages = Library.values.map((library) => Package(
+        library: library,
+        release: Package.latestReleases[library]!,
+        edition: edition,
+        target: Target.host,
+      ));
+
+  if (!areMergedNativeLibrariesInstalled(
+    packages,
+    directory: mergedNativeLibrariesDir,
+  )) {
+    await installMergedNativeLibraries(
+      packages,
+      directory: mergedNativeLibrariesDir,
+    );
+  }
+
+  final libraryConfiguration = mergedNativeLibraryConfigurations(
+    packages,
+    directory: mergedNativeLibrariesDir,
+  );
+
+  return Libraries(
+    enterpriseEdition: edition == Edition.enterprise,
+    cbl: libraryConfiguration[Library.libcblite]!,
+    cblDart: libraryConfiguration[Library.libcblitedart]!,
+  );
+}
+
+String get _homeDir => Platform.environment['HOME']!;
+
+String? sharedCacheDirOverride;
+
+String _sharedCacheDir() {
+  if (sharedCacheDirOverride != null) {
+    return sharedCacheDirOverride!;
+  }
+
+  if (Platform.isMacOS) {
+    return '$_homeDir/Library/Caches/cbl_dart';
+  } else if (Platform.isLinux) {
+    return '$_homeDir/.cache/cbl_dart';
+  } else {
+    throw UnsupportedError('Unsupported platform.');
+  }
+}
+
+String _sharedMergedNativesLibrariesDir() =>
+    p.join(_sharedCacheDir(), 'merged_native_libraries');

--- a/packages/cbl_dart/lib/src/install_libraries.dart
+++ b/packages/cbl_dart/lib/src/install_libraries.dart
@@ -89,7 +89,14 @@ LibraryConfiguration nativeLibraryConfiguration(
 }) {
   if (Platform.isMacOS || Platform.isLinux) {
     final libraryFile = p.join(directory, package.library.name);
-    return LibraryConfiguration.dynamic(libraryFile);
+    return LibraryConfiguration.dynamic(
+      libraryFile,
+      // Specifying an exact version should not be necessary, but is because
+      // the beta of libcblite does not distribute properly symlinked libraries
+      // for macos. We need to use the libcblite.x.dylib because that is what
+      // libcblitedart is linking against.
+      version: package.version.split('.').first,
+    );
   } else {
     throw UnsupportedError('Unsupported platform.');
   }

--- a/packages/cbl_dart/lib/src/install_libraries.dart
+++ b/packages/cbl_dart/lib/src/install_libraries.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+
+import 'package:cbl/cbl.dart';
+import 'package:path/path.dart' as p;
+
+import 'package.dart';
+import 'tools.dart';
+import 'utils.dart';
+
+Directory mergedNativeLibrariesInstallDir(
+  Iterable<Package> packages,
+  String directory,
+) {
+  final signature = Package.mergedSignature(packages);
+  return Directory(p.join(directory, signature));
+}
+
+bool areMergedNativeLibrariesInstalled(
+  Iterable<Package> packages, {
+  required String directory,
+}) =>
+    mergedNativeLibrariesInstallDir(packages, directory).existsSync();
+
+Future<void> installMergedNativeLibraries(
+  Iterable<Package> packages, {
+  required String directory,
+}) async {
+  final tmpDir = await Directory.systemTemp.createTemp();
+
+  try {
+    final tmpInstallDir = Directory.fromUri(tmpDir.uri.resolve('lib'));
+    await tmpInstallDir.create(recursive: true);
+
+    await Future.wait(packages.map((package) => installNativeLibrary(
+          package,
+          installDir: tmpInstallDir.path,
+          tmpDir: tmpDir.path,
+        )));
+
+    final installDir = mergedNativeLibrariesInstallDir(packages, directory);
+    await installDir.create(recursive: true);
+    await copyDirectoryContents(
+      tmpInstallDir.path,
+      installDir.path,
+      filter: (entity) => !entity.path.contains('cmake'),
+    );
+  } finally {
+    await tmpDir.delete(recursive: true);
+  }
+}
+
+Map<Library, LibraryConfiguration> mergedNativeLibraryConfigurations(
+  Iterable<Package> packages, {
+  required String directory,
+}) {
+  final libraryDir = mergedNativeLibrariesInstallDir(packages, directory);
+
+  return Map.fromIterables(
+    packages.map((package) => package.library),
+    packages.map((package) => nativeLibraryConfiguration(
+          package,
+          directory: libraryDir.path,
+        )),
+  );
+}
+
+Future<void> installNativeLibrary(
+  Package package, {
+  required String installDir,
+  required String tmpDir,
+}) async {
+  final archiveBasename =
+      '${package.library.name}.${package.archiveFormat.ext}';
+  final archiveFile = p.join(tmpDir, archiveBasename);
+  final packageRootDir =
+      p.join(tmpDir, '${package.library.name}-${package.version}');
+  final targetLibDir = p.join(packageRootDir, package.targetLibDir);
+
+  await downloadFile(package.archiveUrl, archiveFile);
+  await unpackArchive(archiveFile, tmpDir);
+
+  // Copy contents of lib dir from archive to install dir.
+  await copyDirectoryContents(targetLibDir, installDir);
+}
+
+LibraryConfiguration nativeLibraryConfiguration(
+  Package package, {
+  required String directory,
+}) {
+  if (Platform.isMacOS || Platform.isLinux) {
+    final libraryFile = p.join(directory, package.library.name);
+    return LibraryConfiguration.dynamic(libraryFile);
+  } else {
+    throw UnsupportedError('Unsupported platform.');
+  }
+}

--- a/packages/cbl_dart/lib/src/package.dart
+++ b/packages/cbl_dart/lib/src/package.dart
@@ -1,0 +1,158 @@
+// ignore_for_file: non_constant_identifier_names
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+
+import 'utils.dart';
+
+/// An archive format, in which [Package]s are distributed.
+enum ArchiveFormat {
+  zip,
+  tarGz,
+}
+
+extension ArchiveFormatExt on ArchiveFormat {
+  String get ext {
+    switch (this) {
+      case ArchiveFormat.zip:
+        return 'zip';
+      case ArchiveFormat.tarGz:
+        return 'tar.gz';
+    }
+  }
+}
+
+/// A library that is distributed as part of cbl-dart.
+enum Library {
+  libcblite,
+  libcblitedart,
+}
+
+/// A Couchbase Lite edition.
+enum Edition {
+  community,
+  enterprise,
+}
+
+/// An operating system.
+enum OS { android, ios, macos, linux }
+
+/// A linux distribution.
+enum Distro { ubuntu }
+
+/// A target for which a specific [Package] is distributed.
+class Target {
+  Target(this.os);
+
+  static final android = Target(OS.android);
+  static final ios = Target(OS.ios);
+  static final macos = Target(OS.macos);
+  static final ubuntu20_04_x86_64 =
+      LinuxTarget(OS.linux, Distro.ubuntu, '20.04', 'x86_64');
+
+  static final all = [android, ios, macos, ubuntu20_04_x86_64];
+
+  /// The target of the host machine.
+  static Target get host {
+    if (Platform.isMacOS) {
+      return macos;
+    } else if (Platform.isLinux) {
+      // TODO(blaugold): detect distro and throw if not supported
+      // The only currently supported Linux target is Ubuntu 20.04 x86_64.
+      return ubuntu20_04_x86_64;
+    } else {
+      throw UnsupportedError('Unsupported host platform');
+    }
+  }
+
+  final OS os;
+
+  /// The identifier for this target, as used in the package file names.
+  String get id => os.name;
+}
+
+/// A linux [Target].
+class LinuxTarget extends Target {
+  LinuxTarget(OS os, this.vendor, this.version, this.arch) : super(os);
+
+  final Distro vendor;
+  final String version;
+  final String arch;
+
+  @override
+  String get id => '${vendor.name}$version-$arch';
+}
+
+/// A package though which a release of a [Library] is distributed.
+class Package {
+  Package({
+    required this.library,
+    required this.release,
+    required this.edition,
+    required this.target,
+  });
+
+  static const latestReleases = {
+    Library.libcblite: '3.0.0-beta02',
+    Library.libcblitedart: '1.0.0-beta.3',
+  };
+
+  static final _archiveUrlResolvers = <Library, String Function(Package)>{
+    Library.libcblite: (package) => 'https://packages.couchbase.com/releases/'
+        'couchbase-lite-c/${package.release}/'
+        'couchbase-lite-c-${package.edition.name}-${package.release}-'
+        '${package.target.id}.${package.archiveFormat.ext}',
+    Library.libcblitedart: (package) =>
+        'https://github.com/cbl-dart/cbl-dart/releases/download/'
+        'libcblitedart-v${package.release}/'
+        'couchbase-lite-dart-${package.release}-${package.edition.name}-'
+        '${package.target.id}.${package.archiveFormat.ext}'
+  };
+
+  static String mergedSignature(Iterable<Package> packages) {
+    final signatures =
+        packages.map((package) => package._signatureContent).toList()..sort();
+
+    return md5
+        .convert(utf8.encode(signatures.join()))
+        .bytes
+        .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
+        .join();
+  }
+
+  final Library library;
+  final String release;
+  final Edition edition;
+  final Target target;
+
+  String get version => release.split('-').first;
+
+  ArchiveFormat get archiveFormat {
+    if (target is LinuxTarget) {
+      return ArchiveFormat.tarGz;
+    }
+    return ArchiveFormat.zip;
+  }
+
+  String get archiveUrl => _archiveUrlResolvers[library]!(this);
+
+  String get targetLibDir {
+    final target = this.target;
+
+    if ([OS.ios, OS.android].contains(target.os)) {
+      throw UnsupportedError('targetLibDir is not supported for ${target.os}');
+    }
+
+    if (target is LinuxTarget) {
+      return p.join('lib', '${target.arch}-linux-gnu');
+    }
+
+    return 'lib';
+  }
+
+  String get _signatureContent =>
+      [library.name, release, edition.name, target.id].join();
+}

--- a/packages/cbl_dart/lib/src/utils.dart
+++ b/packages/cbl_dart/lib/src/utils.dart
@@ -1,0 +1,3 @@
+extension EnumNameExt on Enum {
+  String get name => toString().split('.').last;
+}

--- a/packages/cbl_dart/pubspec.yaml
+++ b/packages/cbl_dart/pubspec.yaml
@@ -1,0 +1,22 @@
+name: cbl_dart
+version: 1.0.0-beta.0
+description: >-
+  Couchbase Lite for pure Dart apps: An embedded, NoSQL JSON Document Style
+  database, supporting Blobs, Encryption, N1QL Queries, Live Queries, Full-Text
+  Search and Data Sync.
+homepage: https://github.com/cbl-dart/cbl-dart/tree/main/packages/cbl_dart
+repository: https://github.com/cbl-dart/cbl-dart
+issue_tracker: https://github.com/cbl-dart/cbl-dart/issues
+
+environment:
+  sdk: '>=2.13.0 <3.0.0'
+
+dependencies:
+  cbl: ^1.0.0-beta.9
+  cbl_libcblite_api: 3.0.0-beta.2
+  cbl_libcblitedart_api: 1.0.0-beta.3
+  crypto: ^3.0.1
+  path: ^1.8.0
+
+dev_dependencies:
+  test: ^1.17.2

--- a/packages/cbl_dart/test/init_with_files_dir_test.dart
+++ b/packages/cbl_dart/test/init_with_files_dir_test.dart
@@ -8,10 +8,9 @@ import 'package:test/test.dart';
 void main() {
   test('database is created in filesDir', () async {
     final filesDir = await Directory.systemTemp.createTemp();
-    Directory.current = filesDir.path;
 
     await CouchbaseLiteDart.init(
-      edition: Edition.community,
+      edition: Edition.enterprise,
       filesDir: filesDir.path,
     );
 

--- a/packages/cbl_dart/test/init_with_files_dir_test.dart
+++ b/packages/cbl_dart/test/init_with_files_dir_test.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:cbl/cbl.dart';
+import 'package:cbl_dart/cbl_dart.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  test('database is created in filesDir', () async {
+    final filesDir = await Directory.systemTemp.createTemp();
+    Directory.current = filesDir.path;
+
+    await CouchbaseLiteDart.init(
+      edition: Edition.community,
+      filesDir: filesDir.path,
+    );
+
+    final db = await Database.openAsync('a');
+    await db.close();
+
+    final databaseFile =
+        Directory(p.join(filesDir.path, 'CouchbaseLite', 'a.cblite2'));
+    expect(databaseFile.existsSync(), isTrue);
+  });
+}

--- a/packages/cbl_dart/test/init_with_native_libraries_dir_test.dart
+++ b/packages/cbl_dart/test/init_with_native_libraries_dir_test.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:cbl_dart/cbl_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'merged native libraries should be stored in provided directory',
+    () async {
+      final nativeLibrariesDir = await Directory.systemTemp.createTemp();
+
+      await CouchbaseLiteDart.init(
+        edition: Edition.enterprise,
+        nativeLibrariesDir: nativeLibrariesDir.path,
+      );
+
+      expect(nativeLibrariesDir.existsSync(), isTrue);
+      expect(nativeLibrariesDir.listSync(), hasLength(1));
+    },
+  );
+}

--- a/packages/cbl_dart/test/init_without_files_dir_test.dart
+++ b/packages/cbl_dart/test/init_without_files_dir_test.dart
@@ -13,6 +13,8 @@ void main() {
       'TODO: enable when cbl uses current working directory for default db dir',
     );
     final workingDir = await Directory.systemTemp.createTemp();
+    // Note: There might be a problem with tests changing the current working
+    // directory.
     Directory.current = workingDir.path;
 
     await CouchbaseLiteDart.init(edition: Edition.enterprise);

--- a/packages/cbl_dart/test/init_without_files_dir_test.dart
+++ b/packages/cbl_dart/test/init_without_files_dir_test.dart
@@ -1,0 +1,26 @@
+// ignore_for_file: dead_code
+
+import 'dart:io';
+
+import 'package:cbl/cbl.dart';
+import 'package:cbl_dart/cbl_dart.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  test('database is created in working directory', () async {
+    return markTestSkipped(
+      'TODO: enable when cbl uses current working directory for default db dir',
+    );
+    final workingDir = await Directory.systemTemp.createTemp();
+    Directory.current = workingDir.path;
+
+    await CouchbaseLiteDart.init(edition: Edition.enterprise);
+
+    final db = await Database.openAsync('a');
+    await db.close();
+
+    final databaseFile = Directory(p.join(workingDir.path, 'a.cblite2'));
+    expect(databaseFile.existsSync(), isTrue);
+  });
+}

--- a/packages/cbl_dart/test/init_without_native_libraries_dir_test.dart
+++ b/packages/cbl_dart/test/init_without_native_libraries_dir_test.dart
@@ -1,0 +1,23 @@
+import 'dart:io';
+
+import 'package:cbl_dart/cbl_dart.dart';
+import 'package:cbl_dart/src/acquire_libraries.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'merged native libraries should be stored in system-wide shared directory',
+    () async {
+      sharedCacheDirOverride = (await Directory.systemTemp.createTemp()).path;
+
+      await CouchbaseLiteDart.init(edition: Edition.enterprise);
+
+      final sharedMergeNativeLibraries =
+          Directory(p.join(sharedCacheDirOverride!, 'merged_native_libraries'));
+
+      expect(sharedMergeNativeLibraries.existsSync(), isTrue);
+      expect(sharedMergeNativeLibraries.listSync(), hasLength(1));
+    },
+  );
+}

--- a/packages/cbl_dart/test/install_libraries_test.dart
+++ b/packages/cbl_dart/test/install_libraries_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:cbl_dart/src/install_libraries.dart';
+import 'package:cbl_dart/src/package.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  test('install merged native libraries', () async {
+    final installDir = await Directory.systemTemp.createTemp();
+
+    final packages = Library.values.map((library) => Package(
+          library: library,
+          release: Package.latestReleases[library]!,
+          edition: Edition.enterprise,
+          target: Target.host,
+        ));
+
+    await installMergedNativeLibraries(packages, directory: installDir.path);
+
+    final installDirEntries = installDir.listSync();
+    expect(installDirEntries, hasLength(1));
+
+    final libDir = installDirEntries.first as Directory;
+    expect(p.basename(libDir.path), Package.mergedSignature(packages));
+
+    final libDirEntries = libDir.listSync();
+    final libDirBasenames =
+        libDirEntries.map((entry) => p.basename(entry.path)).toList();
+
+    expect(
+      libDirBasenames,
+      containsAll(<Object>[
+        startsWith('libcblite'),
+        startsWith('libcblitedart'),
+      ]),
+    );
+  });
+}

--- a/packages/cbl_flutter/README.md
+++ b/packages/cbl_flutter/README.md
@@ -79,10 +79,10 @@ various platforms.
 Flutter unit tests are executed by a headless version of Flutter, on the
 development host.
 
+> 🚧 `cbl_dart` is not yet implemented for Windows.
+
 You can use the `cbl` package in your unit tests, but you need to use
 [`cbl_dart`][cbl_dart] to initialize Couchbase Lite, instead of `cbl_flutter`:
-
-> 🚧 `cbl_dart` is not yet implemented for Windows.
 
 ```dart
 import 'dart:io';
@@ -92,7 +92,6 @@ import 'package:cbl_dart/cbl_dart.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-
   setupAll(() async {
     // If no `filesDir` is specified when initializing CouchbaseLiteDart, the
     // working directory is used as the default database directory.

--- a/packages/cbl_flutter/README.md
+++ b/packages/cbl_flutter/README.md
@@ -25,11 +25,11 @@ the use of `cbl` in Flutter apps.
 
 1. Add [`cbl`][cbl] and `cbl_flutter` as dependencies:
 
-```yaml
-dependencies:
-  cbl: ...
-  cbl_flutter: ...
-```
+   ```yaml
+   dependencies:
+     cbl: ...
+     cbl_flutter: ...
+   ```
 
 2. Select the edition of Couchbase Lite you want to use, by adding as a
    dependency either [`cbl_flutter_ce`](https://pub.dev/packages/cbl_flutter_ce)
@@ -37,35 +37,35 @@ dependencies:
    [`cbl_flutter_ee`](https://pub.dev/packages/cbl_flutter_ee) for the
    Enterprise Edition:
 
-```yaml
-  # This dependency selects the Couchbase Lite Community Edition.
-  cbl_flutter_ce: ...
-```
+   ```yaml
+   # This dependency selects the Couchbase Lite Community Edition.
+   cbl_flutter_ce: ...
+   ```
 
-> ⚖️ You need to comply with the Couchbase licensing terms of the edition of
-> Couchbase Lite you select.
+   > ⚖️ You need to comply with the Couchbase licensing terms of the edition of
+   > Couchbase Lite you select.
 
 3. Make sure you have set the required minimum target version in the build
    systems of the platforms you support.
 
-4. Initialize Couchbase Lite, before using it:
+4. Initialize Couchbase Lite before using it:
 
-```dart
-import 'dart:io';
+   ```dart
+   import 'dart:io';
 
-import 'package:cbl_flutter/cbl_flutter.dart';
-import 'package:cbl_flutter_ce/cbl_flutter_ce.dart';
+   import 'package:cbl_flutter/cbl_flutter.dart';
+   import 'package:cbl_flutter_ce/cbl_flutter_ce.dart';
 
-Future<void> initCouchbaseLite() async {
-  // On mobile platforms, `CblFlutterCe` and `CblFlutterEe` currently need to
-  // be registered manually. This is due to a temporary limitation in how Flutter
-  // initializes plugins, and will become obsolete eventually.
-  if (Platform.isIOS || Platform.isAndroid) {
-    CblFlutterCe.registerWith();
-  }
-  await CouchbaseLiteFlutter.init();
-}
-```
+   Future<void> initCouchbaseLite() async {
+     // On mobile platforms, `CblFlutterCe` and `CblFlutterEe` currently need to
+     // be registered manually. This is due to a temporary limitation in how Flutter
+     // initializes plugins, and will become obsolete eventually.
+     if (Platform.isIOS || Platform.isAndroid) {
+       CblFlutterCe.registerWith();
+     }
+     await CouchbaseLiteFlutter.init();
+   }
+   ```
 
 # Default database directory
 
@@ -73,6 +73,51 @@ When opening a database without specifying a directory,
 [`path_provider`][path_provider]'s `getApplicationSupportDirectory` is used to
 resolve it. See that function's documentation for the concrete locations on the
 various platforms.
+
+# 🧪 Flutter unit tests
+
+Flutter unit tests are executed by a headless version of Flutter, on the
+development host.
+
+You can use the `cbl` package in your unit tests, but you need to use
+[`cbl_dart`][cbl_dart] to initialize Couchbase Lite, instead of `cbl_flutter`:
+
+> 🚧 `cbl_dart` is not yet implemented for Windows.
+
+```dart
+import 'dart:io';
+
+import 'package:cbl/cbl.dart';
+import 'package:cbl_dart/cbl_dart.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+
+  setupAll(() async {
+    // If no `filesDir` is specified when initializing CouchbaseLiteDart, the
+    // working directory is used as the default database directory.
+    // By specifying a `filesDir` here, we can ensure that the tests don't
+    // create databases in the project directory.
+    final tempFilesDir = await Directory.systemTemp.createTemp();
+    CouchbaseLiteDart.init(edition: Edition.community, filesDir: tempFilesDir.path);
+  });
+
+  test('use a database', () async {
+    final db = await Database.openAsync('test');
+    await db.saveDocument(MutableDocument({'message': 'Hello, World!'}));
+    await db.close();
+  });
+}
+```
+
+Unit tests are the best way to **learn, experiment and validate ideas**, since
+they launch much quicker than integration tests. Be aware though, that using
+Couchbase Lite like this **cannot replace integration testing** your database
+code on actual devices or even simulators.
+
+These tests can validate that you're using Couchbase Lite correctly and the code
+works as expected generally, but subtle differences between platforms, operating
+system versions and devices can still crop up.
 
 # 💡 Where to go next
 
@@ -85,4 +130,5 @@ various platforms.
 
 [path_provider]: https://pub.dev/packages/path_provider
 [cbl]: https://pub.dev/packages/cbl
+[cbl_dart]: https://pub.dev/packages/cbl_dart
 [issues]: https://github.com/cbl-dart/cbl-dart/issues


### PR DESCRIPTION
This packages allows pure Dart apps to use Couchbase Lite withouth having to manually manage the native libraries.