### PR TITLE
refactor: clean up `libcblitedart`

### DIFF
--- a/native/couchbase-lite-dart/include/CBL+Dart.h
+++ b/native/couchbase-lite-dart/include/CBL+Dart.h
@@ -31,7 +31,9 @@ CBLDART_EXPORT
 bool CBLDart_Initialize(void *dartInitializeDlData, void *cblInitContext,
                         CBLError *errorOut);
 
-// -- Callbacks
+// === Dart Native ============================================================
+
+// === Async Callbacks
 
 typedef struct _CBLDart_AsyncCallback *CBLDart_AsyncCallback;
 
@@ -47,15 +49,15 @@ CBLDART_EXPORT
 void CBLDart_AsyncCallback_CallForTest(CBLDart_AsyncCallback callback,
                                        int64_t argument);
 
-// -- Dart Finalizer
+// === Dart Finalizer
 
 CBLDART_EXPORT
 void CBLDart_RegisterDartFinalizer(Dart_Handle object, Dart_Port registry,
                                    int64_t token);
 
-// Couchbase Lite ----------------------------------------------------------
+// === Couchbase Lite =========================================================
 
-// -- Base
+// === Base
 
 CBLDART_EXPORT
 CBLDart_FLStringResult CBLDart_CBLError_Message(CBLError *error);
@@ -79,7 +81,7 @@ void CBLDart_BindCBLRefCountedToDartObject(Dart_Handle object,
 CBLDART_EXPORT
 void CBLDart_SetDebugRefCounted(uint8_t enabled);
 
-// -- Log
+// === Log
 
 CBLDART_EXPORT
 void CBLDart_CBL_LogMessage(CBLLogDomain domain, CBLLogLevel level,
@@ -109,7 +111,7 @@ CBLDart_CBLLogFileConfiguration *CBLDart_CBLLog_GetFileConfig();
 CBLDART_EXPORT
 bool CBLDart_CBLLog_SetSentryBreadcrumbs(bool enabled);
 
-// -- Document
+// === Document
 
 CBLDART_EXPORT
 CBLDart_FLString CBLDart_CBLDocument_ID(CBLDocument *doc);
@@ -127,7 +129,7 @@ CBLDART_EXPORT
 int8_t CBLDart_CBLDocument_SetJSON(CBLDocument *doc, CBLDart_FLString json,
                                    CBLError *errorOut);
 
-// -- Database
+// === Database
 
 #ifdef COUCHBASE_ENTERPRISE
 CBLDART_EXPORT
@@ -244,7 +246,7 @@ CBLDART_EXPORT
 uint8_t CBLDart_CBLDatabase_DeleteIndex(CBLDatabase *db, CBLDart_FLString name,
                                         CBLError *errorOut);
 
-// -- Query
+// === Query
 
 CBLDART_EXPORT
 CBLQuery *CBLDart_CBLDatabase_CreateQuery(CBLDatabase *db,
@@ -267,7 +269,7 @@ CBLDART_EXPORT
 CBLListenerToken *CBLDart_CBLQuery_AddChangeListener(
     CBLQuery *query, CBLDart_AsyncCallback listener);
 
-// -- Blob
+// === Blob
 
 CBLDART_EXPORT
 CBLDart_FLString CBLDart_CBLBlob_Digest(CBLBlob *blob);
@@ -295,7 +297,7 @@ CBLBlob *CBLDart_CBLBlob_CreateWithData(CBLDart_FLString contentType,
 CBLDART_EXPORT CBLBlob *CBLDart_CBLBlob_CreateWithStream(
     CBLDart_FLString contentType, CBLBlobWriteStream *writer);
 
-// -- Replicator
+// === Replicator
 
 CBLDART_EXPORT
 CBLEndpoint *CBLDart_CBLEndpoint_CreateWithURL(CBLDart_FLString url,

--- a/native/couchbase-lite-dart/include/Fleece+Dart.h
+++ b/native/couchbase-lite-dart/include/Fleece+Dart.h
@@ -9,7 +9,8 @@
 #endif
 
 extern "C" {
-// Slice -------------------------------------------------------------------
+
+// === Slice ==================================================================
 
 /**
  * See `FLSlice` in Dart code.
@@ -26,24 +27,6 @@ struct CBLDart_FLSliceResult {
 
 typedef CBLDart_FLSlice CBLDart_FLString;
 typedef CBLDart_FLSliceResult CBLDart_FLStringResult;
-
-#define kCBLDartNullSlice ((CBLDart_FLSlice){NULL, 0})
-
-FLSlice CBLDart_FLSliceFromDart(CBLDart_FLSlice slice);
-
-CBLDart_FLSlice CBLDart_FLSliceToDart(FLSlice slice);
-
-FLSliceResult CBLDart_FLSliceResultFromDart(CBLDart_FLSliceResult slice);
-
-CBLDart_FLSliceResult CBLDart_FLSliceResultToDart(FLSliceResult slice);
-
-FLString CBLDart_FLStringFromDart(CBLDart_FLString slice);
-
-CBLDart_FLString CBLDart_FLStringToDart(FLString slice);
-
-FLStringResult CBLDart_FLStringResultFromDart(CBLDart_FLStringResult slice);
-
-CBLDart_FLStringResult CBLDart_FLStringResultToDart(FLStringResult slice);
 
 CBLDART_EXPORT
 uint8_t CBLDart_FLSlice_Equal(CBLDart_FLSlice a, CBLDart_FLSlice b);
@@ -68,7 +51,7 @@ void CBLDart_FLSliceResult_Retain(CBLDart_FLSliceResult slice);
 CBLDART_EXPORT
 void CBLDart_FLSliceResult_Release(CBLDart_FLSliceResult slice);
 
-// Doc ---------------------------------------------------------------------
+// === Doc ====================================================================
 
 CBLDART_EXPORT
 FLDoc CBLDart_FLDoc_FromResultData(CBLDart_FLSliceResult data, uint8_t trust,
@@ -81,7 +64,7 @@ FLDoc CBLDart_FLDoc_FromJSON(CBLDart_FLString json, FLError *errorOut);
 CBLDART_EXPORT
 void CBLDart_FLDoc_BindToDartObject(Dart_Handle object, FLDoc doc);
 
-// Value -------------------------------------------------------------------
+// === Value ==================================================================
 
 CBLDART_EXPORT
 void CBLDart_FLValue_BindToDartObject(Dart_Handle object, FLValue value,
@@ -100,7 +83,7 @@ CBLDART_EXPORT
 CBLDart_FLStringResult CBLDart_FLValue_ToJSONX(FLValue value, uint8_t json5,
                                                uint8_t canonicalForm);
 
-// Dict --------------------------------------------------------------------
+// === Dict ===================================================================
 
 CBLDART_EXPORT
 FLValue CBLDart_FLDict_Get(FLDict dict, CBLDart_FLString keyString);
@@ -135,7 +118,7 @@ CBLDART_EXPORT
 FLMutableDict CBLDart_FLMutableDict_GetMutableDict(FLMutableDict dict,
                                                    CBLDart_FLString key);
 
-// Decoder --------------------------------------------------------------------
+// === Decoder ================================================================
 
 struct CBLDart_LoadedFLValue {
   uint8_t exists;
@@ -183,7 +166,7 @@ CBLDart_FLDictIterator2 *CBLDart_FLDictIterator2_Begin(
 CBLDART_EXPORT
 void CBLDart_FLDictIterator2_Next(CBLDart_FLDictIterator2 *iterator);
 
-// Encoder --------------------------------------------------------------------
+// === Encoder ================================================================
 
 CBLDART_EXPORT
 void CBLDart_FLEncoder_BindToDartObject(Dart_Handle object, FLEncoder encoder);

--- a/native/couchbase-lite-dart/src/Sentry.cpp
+++ b/native/couchbase-lite-dart/src/Sentry.cpp
@@ -13,12 +13,12 @@ typedef sentry_value_t (*sentry_value_new_breadcrumb_t)(const char *type,
 typedef void (*sentry_add_breadcrumb_t)(sentry_value_t breadcrumb);
 
 // Function pointers
-sentry_value_new_string_t sentry_value_new_string_fp = nullptr;
-sentry_value_set_by_key_t sentry_value_set_by_key_fp = nullptr;
-sentry_value_new_breadcrumb_t sentry_value_new_breadcrumb_fp = nullptr;
-sentry_add_breadcrumb_t sentry_add_breadcrumb_fp = nullptr;
+static sentry_value_new_string_t sentry_value_new_string_fp = nullptr;
+static sentry_value_set_by_key_t sentry_value_set_by_key_fp = nullptr;
+static sentry_value_new_breadcrumb_t sentry_value_new_breadcrumb_fp = nullptr;
+static sentry_add_breadcrumb_t sentry_add_breadcrumb_fp = nullptr;
 
-bool sentryAPIisAvailable = false;
+static bool sentryAPIisAvailable = false;
 
 bool CBLDart_InitSentryAPI() {
   static std::once_flag initFlag;

--- a/native/couchbase-lite-dart/src/Utils.cpp
+++ b/native/couchbase-lite-dart/src/Utils.cpp
@@ -1,5 +1,7 @@
 #include "Utils.h"
 
+// === Dart Native ============================================================
+
 int64_t CBLDart_CObject_getIntValueAsInt64(Dart_CObject* object) {
   assert(object->type == Dart_CObject_kInt64 ||
          object->type == Dart_CObject_kInt32);
@@ -31,4 +33,42 @@ void CBLDart_CObject_SetFLString(Dart_CObject* object, const FLString string) {
   } else {
     object->type = Dart_CObject_kNull;
   }
+}
+
+// === Fleece =================================================================
+
+FLSlice CBLDart_FLSliceFromDart(CBLDart_FLSlice slice) {
+  return {slice.buf, static_cast<size_t>(slice.size)};
+}
+
+CBLDart_FLSlice CBLDart_FLSliceToDart(FLSlice slice) {
+  return {slice.buf, slice.size};
+}
+
+FLSliceResult CBLDart_FLSliceResultFromDart(CBLDart_FLSliceResult slice) {
+  return {slice.buf, static_cast<size_t>(slice.size)};
+}
+
+CBLDart_FLSliceResult CBLDart_FLSliceResultToDart(FLSliceResult slice) {
+  return {slice.buf, slice.size};
+}
+
+FLString CBLDart_FLStringFromDart(CBLDart_FLString slice) {
+  return {slice.buf, static_cast<size_t>(slice.size)};
+}
+
+CBLDart_FLString CBLDart_FLStringToDart(FLString slice) {
+  return {slice.buf, slice.size};
+}
+
+FLStringResult CBLDart_FLStringResultFromDart(CBLDart_FLStringResult slice) {
+  return {slice.buf, static_cast<size_t>(slice.size)};
+}
+
+CBLDart_FLStringResult CBLDart_FLStringResultToDart(FLStringResult slice) {
+  return {slice.buf, slice.size};
+}
+
+std::string CBLDart_FLStringToString(FLString slice) {
+  return std::string((char*)slice.buf, slice.size);
 }

--- a/native/couchbase-lite-dart/src/Utils.h
+++ b/native/couchbase-lite-dart/src/Utils.h
@@ -4,6 +4,9 @@
 #else
 #include "fleece/Fleece.h"
 #endif
+#include "Fleece+Dart.h"
+
+// === Dart Native ============================================================
 
 /**
  * Returns the value of the given Dart CObject, wich is expected to be either an
@@ -16,3 +19,25 @@ void CBLDart_CObject_SetEmptyArray(Dart_CObject* object);
 void CBLDart_CObject_SetPointer(Dart_CObject* object, const void* pointer);
 
 void CBLDart_CObject_SetFLString(Dart_CObject* object, const FLString string);
+
+// === Fleece =================================================================
+
+#define kCBLDartNullSlice ((CBLDart_FLSlice){NULL, 0})
+
+FLSlice CBLDart_FLSliceFromDart(CBLDart_FLSlice slice);
+
+CBLDart_FLSlice CBLDart_FLSliceToDart(FLSlice slice);
+
+FLSliceResult CBLDart_FLSliceResultFromDart(CBLDart_FLSliceResult slice);
+
+CBLDart_FLSliceResult CBLDart_FLSliceResultToDart(FLSliceResult slice);
+
+FLString CBLDart_FLStringFromDart(CBLDart_FLString slice);
+
+CBLDart_FLString CBLDart_FLStringToDart(FLString slice);
+
+FLStringResult CBLDart_FLStringResultFromDart(CBLDart_FLStringResult slice);
+
+CBLDart_FLStringResult CBLDart_FLStringResultToDart(FLStringResult slice);
+
+std::string CBLDart_FLStringToString(FLString slice);


### PR DESCRIPTION
- make all file private functions and variables `static`
- relocate utility functions to `Utils.h|cpp`
- make section comments consistent