### PR TITLE
feat!: Add `Database.saveBlob` and `Database.getBlob`

### DIFF
--- a/packages/cbl/lib/src/database/blob_store.dart
+++ b/packages/cbl/lib/src/database/blob_store.dart
@@ -10,11 +10,16 @@ abstract class BlobStore {
     Stream<Data> stream,
   );
 
+  FutureOr<bool> blobExists(Map<String, Object?> properties);
+
   Stream<Data>? readBlob(Map<String, Object?> properties);
 }
 
 abstract class SyncBlobStore extends BlobStore {
   Map<String, Object?> saveBlobFromDataSync(String contentType, Data data);
+
+  @override
+  bool blobExists(Map<String, Object?> properties);
 
   Data? readBlobSync(Map<String, Object?> properties);
 }

--- a/packages/cbl/lib/src/database/database.dart
+++ b/packages/cbl/lib/src/database/database.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import '../document/blob.dart';
 import '../document/document.dart';
 import '../document/fragment.dart';
 import '../log.dart';
@@ -247,6 +248,27 @@ abstract class Database implements ClosableResource {
   /// The purge will __not__ be replicated to other databases.
   FutureOr<void> purgeDocumentById(String id);
 
+  /// Saves a [Blob] directly into this database without associating it with any
+  /// [Document]s.
+  ///
+  /// Note: Blobs that are not associated with any document will be removed
+  /// from the database when compacting the database.
+  FutureOr<void> saveBlob(Blob blob);
+
+  /// Gets a [Blob] using its metadata.
+  ///
+  /// If the blob with the specified metadata doesn’t exist, returns `null`.
+  ///
+  /// If the provided [properties] don't contain valid metadata, an
+  /// [ArgumentError] is thrown.
+  ///
+  /// {@macro cbl.Blob.metadataTable}
+  ///
+  /// See also:
+  ///
+  ///   - [Blob.isBlob] to check if a [Map] contains valid Blob metadata.
+  FutureOr<Blob?> getBlob(Map<String, Object?> properties);
+
   /// Runs a group of database operations in a batch.
   ///
   /// {@template cbl.Database.inBatch}
@@ -467,6 +489,12 @@ abstract class SyncDatabase implements Database {
   @override
   void purgeDocumentById(String id);
 
+  @override
+  Future<void> saveBlob(Blob blob);
+
+  @override
+  Blob? getBlob(Map<String, Object?> properties);
+
   /// Runs a group of database operations in a batch, synchronously.
   ///
   /// {@macro cbl.Database.inBatch}
@@ -565,6 +593,12 @@ abstract class AsyncDatabase implements Database {
 
   @override
   Future<void> purgeDocumentById(String id);
+
+  @override
+  Future<void> saveBlob(Blob blob);
+
+  @override
+  Future<Blob?> getBlob(Map<String, Object?> properties);
 
   @override
   Future<void> inBatch(FutureOr<void> Function() fn);

--- a/packages/cbl/lib/src/database/ffi_blob_store.dart
+++ b/packages/cbl/lib/src/database/ffi_blob_store.dart
@@ -48,6 +48,21 @@ class FfiBlobStore implements BlobStore, SyncBlobStore {
   }
 
   @override
+  bool blobExists(Map<String, Object?> properties) {
+    final dict = MutableDict(properties);
+    final cblBlob = runNativeCalls(
+        () => _databaseBindings.getBlob(database.pointer, dict.pointer.cast()));
+
+    if (cblBlob == null) {
+      return false;
+    }
+
+    cblBindings.base.releaseRefCounted(cblBlob.cast());
+
+    return true;
+  }
+
+  @override
   Data? readBlobSync(Map<String, Object?> properties) =>
       _getBlob(properties)?.let((it) => it.native.call(_blobBindings.content));
 

--- a/packages/cbl/lib/src/database/ffi_database.dart
+++ b/packages/cbl/lib/src/database/ffi_database.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:cbl_ffi/cbl_ffi.dart';
 
+import '../document/blob.dart';
 import '../document/document.dart';
 import '../document/ffi_document.dart';
 import '../document/fragment.dart';
@@ -87,7 +88,7 @@ class FfiDatabase extends CBLDatabaseObject
       });
 
   @override
-  late final blobStore = FfiBlobStore(this);
+  late final SyncBlobStore blobStore = FfiBlobStore(this);
 
   late final _listenerTokens = ListenerTokenRegistry(this);
 
@@ -193,6 +194,18 @@ class FfiDatabase extends CBLDatabaseObject
   @override
   void purgeDocumentById(String id) => useSync(() {
         call((pointer) => _bindings.purgeDocumentByID(pointer, id));
+      });
+
+  @override
+  Future<void> saveBlob(covariant BlobImpl blob) => use(
+      () => blob.ensureIsInstalled(this, allowFromStreamForSyncDatabase: true));
+
+  @override
+  Blob? getBlob(Map<String, Object?> properties) => useSync(() {
+        checkBlobMetadata(properties);
+        if (blobStore.blobExists(properties)) {
+          return BlobImpl.fromProperties(properties, database: this);
+        }
       });
 
   @override

--- a/packages/cbl/lib/src/database/proxy_blob_store.dart
+++ b/packages/cbl/lib/src/database/proxy_blob_store.dart
@@ -10,6 +10,13 @@ class ProxyBlobStore implements BlobStore {
   final ProxyDatabase database;
 
   @override
+  Future<bool> blobExists(Map<String, Object?> properties) =>
+      database.channel.call(BlobExists(
+        databaseId: database.objectId,
+        properties: properties,
+      ));
+
+  @override
   Stream<Data>? readBlob(Map<String, Object?> properties) =>
       database.channel.stream(ReadBlob(
         databaseId: database.objectId,

--- a/packages/cbl/lib/src/database/proxy_database.dart
+++ b/packages/cbl/lib/src/database/proxy_database.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../document.dart';
+import '../document/blob.dart';
 import '../document/document.dart';
 import '../document/fragment.dart';
 import '../document/proxy_document.dart';
@@ -184,6 +185,18 @@ class ProxyDatabase extends ProxyObject
   @override
   Future<void> purgeDocumentById(String id) =>
       use(() => channel.call(PurgeDocument(objectId, id)));
+
+  @override
+  Future<void> saveBlob(covariant BlobImpl blob) =>
+      use(() => blob.ensureIsInstalled(this));
+
+  @override
+  Future<Blob?> getBlob(Map<String, Object?> properties) => use(() async {
+        checkBlobMetadata(properties);
+        if (await blobStore.blobExists(properties)) {
+          return BlobImpl.fromProperties(properties, database: this);
+        }
+      });
 
   @override
   Future<void> inBatch(FutureOr<void> Function() fn) => use(() async {

--- a/packages/cbl/lib/src/service/cbl_service.dart
+++ b/packages/cbl/lib/src/service/cbl_service.dart
@@ -271,6 +271,7 @@ class CblService {
       ..addCallEndpoint(_addDocumentChangeListener)
       ..addCallEndpoint(_deleteIndex)
       ..addCallEndpoint(_createIndex)
+      ..addCallEndpoint(_blobExists)
       ..addStreamEndpoint(_readBlob)
       ..addCallEndpoint(_saveBlob)
       ..addCallEndpoint(_createQuery)
@@ -469,6 +470,10 @@ class CblService {
 
   void _deleteIndex(DeleteIndex request) =>
       _getDatabaseById(request.databaseId).deleteIndex(request.name);
+
+  bool _blobExists(BlobExists request) => _getDatabaseById(request.databaseId)
+      .blobStore
+      .blobExists(request.properties);
 
   Stream<Data> _readBlob(ReadBlob request) =>
       _getDatabaseById(request.databaseId)

--- a/packages/cbl/lib/src/service/cbl_service_api.dart
+++ b/packages/cbl/lib/src/service/cbl_service_api.dart
@@ -92,6 +92,7 @@ SerializationRegistry cblServiceSerializationRegistry() =>
       )
       ..addSerializableCodec('CreateIndex', CreateIndex.deserialize)
       ..addSerializableCodec('DeleteIndex', DeleteIndex.deserialize)
+      ..addSerializableCodec('BlobExists', BlobExists.deserialize)
       ..addSerializableCodec('ReadBlob', ReadBlob.deserialize)
       ..addSerializableCodec('SaveBlob', SaveBlob.deserialize)
       ..addSerializableCodec('ReadBlobUpload', ReadBlobUpload.deserialize)
@@ -1053,6 +1054,31 @@ class DeleteIndex implements Request<Null> {
       DeleteIndex(
         databaseId: map.getAs('databaseId'),
         name: map.getAs('name'),
+      );
+}
+
+class BlobExists implements Request<bool> {
+  BlobExists({
+    required this.databaseId,
+    required this.properties,
+  });
+
+  final int databaseId;
+  final StringMap properties;
+
+  @override
+  StringMap serialize(SerializationContext context) => {
+        'databaseId': databaseId,
+        'properties': properties,
+      };
+
+  static BlobExists deserialize(
+    StringMap map,
+    SerializationContext context,
+  ) =>
+      BlobExists(
+        databaseId: map.getAs('databaseId'),
+        properties: map.getAs('properties'),
       );
 }
 

--- a/packages/cbl/lib/src/support/streams.dart
+++ b/packages/cbl/lib/src/support/streams.dart
@@ -300,8 +300,8 @@ class RepeatableStream<T> extends Stream<T> {
   StreamSubscription<T>? _sourceSub;
   var _sourceDone = false;
   final List<T> _sourceChunks = <T>[];
-  late final Object? _sourceError;
-  late final StackTrace? _sourceStackTrace;
+  Object? _sourceError;
+  StackTrace? _sourceStackTrace;
   final List<MultiStreamController<T>> _destinations = [];
 
   late final Stream<T> _stream = Stream.multi((destination) {
@@ -327,8 +327,6 @@ class RepeatableStream<T> extends Stream<T> {
       }, onDone: () {
         _sourceDone = true;
         _sourceSub = null;
-        _sourceError = null;
-        _sourceStackTrace = null;
 
         for (final controller in _destinations) {
           controller.close();

--- a/packages/cbl/test/support/streams_test.dart
+++ b/packages/cbl/test/support/streams_test.dart
@@ -185,6 +185,62 @@ void main() {
       expect(token.isRemoved, isTrue);
     });
   });
+
+  group('RepeatableStream', () {
+    test('sends events to parallel subscribers', () async {
+      final stream = RepeatableStream(Stream.value('A'));
+      expect(stream, emitsInOrder(<Object>['A', emitsDone]));
+      expect(stream, emitsInOrder(<Object>['A', emitsDone]));
+    });
+
+    test('replay error to parallel subscribers', () async {
+      final stream = RepeatableStream(Stream<void>.error('A'));
+      expect(stream, emitsInOrder(<Object>[emitsError('A'), emitsDone]));
+      expect(stream, emitsInOrder(<Object>[emitsError('A'), emitsDone]));
+    });
+
+    test('replay done to parallel subscriber', () async {
+      final stream = RepeatableStream(const Stream<void>.empty());
+      expect(stream, emitsInOrder(<Object>[emitsDone]));
+      expect(stream, emitsInOrder(<Object>[emitsDone]));
+    });
+
+    test('replay events to late subscribers', () async {
+      final stream = RepeatableStream(Stream.value('A'));
+      await expectLater(
+        stream,
+        emitsInOrder(<Object>['A', emitsDone]),
+      );
+      await expectLater(
+        stream,
+        emitsInOrder(<Object>['A', emitsDone]),
+      );
+    });
+
+    test('replay error to late subscribers', () async {
+      final stream = RepeatableStream(Stream<void>.error('A'));
+      await expectLater(
+        stream,
+        emitsInOrder(<Object>[emitsError('A'), emitsDone]),
+      );
+      await expectLater(
+        stream,
+        emitsInOrder(<Object>[emitsError('A'), emitsDone]),
+      );
+    });
+
+    test('replay done to late subscriber', () async {
+      final stream = RepeatableStream(const Stream<void>.empty());
+      await expectLater(
+        stream,
+        emitsInOrder(<Object>[emitsDone]),
+      );
+      await expectLater(
+        stream,
+        emitsInOrder(<Object>[emitsDone]),
+      );
+    });
+  });
 }
 
 Stream<void> nullSteam() => StreamController<void>().stream;

--- a/packages/cbl_ffi/lib/src/base.dart
+++ b/packages/cbl_ffi/lib/src/base.dart
@@ -296,6 +296,10 @@ typedef _CBL_Retain = Pointer<CBLRefCounted> Function(
   Pointer<CBLRefCounted> refCounted,
 );
 
+typedef _CBL_Release = Pointer<CBLRefCounted> Function(
+  Pointer<CBLRefCounted> refCounted,
+);
+
 // === CBLListener =============================================================
 
 class CBLListenerToken extends Opaque {}
@@ -328,6 +332,9 @@ class BaseBindings extends Bindings {
     _retainRefCounted = libs.cbl.lookupFunction<_CBL_Retain, _CBL_Retain>(
       'CBL_Retain',
     );
+    _releaseRefCounted = libs.cbl.lookupFunction<_CBL_Release, _CBL_Release>(
+      'CBL_Release',
+    );
     _getErrorMessage = libs.cblDart
         .lookupFunction<_CBLDart_CBLError_Message, _CBLDart_CBLError_Message>(
       'CBLDart_CBLError_Message',
@@ -343,6 +350,7 @@ class BaseBindings extends Bindings {
       _bindCBLRefCountedToDartObject;
   late final _CBLDart_SetDebugRefCounted _setDebugRefCounted;
   late final _CBL_Retain _retainRefCounted;
+  late final _CBL_Release _releaseRefCounted;
   late final _CBLDart_CBLError_Message _getErrorMessage;
   late final _CBLListener_Remove _removeListener;
 
@@ -399,6 +407,10 @@ class BaseBindings extends Bindings {
 
   void retainRefCounted(Pointer<CBLRefCounted> refCounted) {
     _retainRefCounted(refCounted);
+  }
+
+  void releaseRefCounted(Pointer<CBLRefCounted> refCounted) {
+    _releaseRefCounted(refCounted);
   }
 
   // coverage:ignore-end


### PR DESCRIPTION
This change adds the methods `Database.saveBlob` and `Database.getBlob`.
They allow saving and retrieving `Blob`s, independently of `Document`s.

This is a breaking change because `Blob.fromStream` is now a factory
instead of a static method returning a `Future`. To get the previous
behavior, create a `Blob` with `Blob.fromStream` and save it with
`Database.saveBlob`.

This change also fixes `Blob.isBlob`.

`Blob.properties` now returns a `Map` that contains full `Blob`
metadata.

Closes #255
Closes #253