### PR TITLE
feat: make source N1QL query string available on `Query` 

### DIFF
--- a/packages/cbl/lib/src/query/query.dart
+++ b/packages/cbl/lib/src/query/query.dart
@@ -170,6 +170,15 @@ abstract class Query implements Resource {
   ///
   /// Is `null`, if this query was created from a N1QL query.
   String? get jsonRepresentation;
+
+  /// The N1QL string of this query.
+  ///
+  /// This value can be used to recreate this query with [SyncQuery.fromN1ql] or
+  /// [AsyncQuery.fromN1ql].
+  ///
+  /// Is `null`, if this query was created through the builder API or from the
+  /// JSON representation.
+  String? get n1ql;
 }
 
 /// A [Query] with a primarily synchronous API.
@@ -306,6 +315,9 @@ abstract class QueryBase with ClosableResourceMixin implements Query {
   @override
   String? get jsonRepresentation =>
       language == CBLQueryLanguage.json ? definition : null;
+
+  @override
+  String? get n1ql => language == CBLQueryLanguage.n1ql ? definition : null;
 
   @override
   String toString() => '$typeName(${describeEnum(language)}: $definition)';

--- a/packages/cbl_e2e_tests/lib/src/query/query_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/query/query_test.dart
@@ -211,6 +211,17 @@ SELECT foo()
       );
     });
 
+    test('get N1QL source string', () {
+      final db = openSyncTestDatabase();
+      final n1qlQuery = SyncQuery.fromN1ql(db, 'SELECT * FROM _');
+      final jsonQuery = const QueryBuilder()
+          .select(SelectResult.all())
+          .from(DataSource.database(db));
+
+      expect(n1qlQuery.n1ql, 'SELECT * FROM _');
+      expect(jsonQuery.n1ql, isNull);
+    });
+
     apiTest('toString', () async {
       final db = await openTestDatabase();
       expect(


### PR DESCRIPTION
Close #271