### PR TITLE
perf: transfer data without copying where possible

### DIFF
--- a/packages/cbl/lib/src/document/ffi_document.dart
+++ b/packages/cbl/lib/src/document/ffi_document.dart
@@ -70,6 +70,12 @@ class FfiDocumentDelegate extends DocumentDelegate
   EncodedData? get properties => _properties ??= _readEncodedProperties();
   EncodedData? _properties;
 
+  fl.Dict get propertiesDict {
+    final result = fl.Dict.fromPointer(_nativeProperties.cast());
+    cblReachabilityFence(native);
+    return result;
+  }
+
   @override
   set properties(EncodedData? value) {
     _writeEncodedProperties(value!);

--- a/packages/cbl/lib/src/replication/proxy_replicator.dart
+++ b/packages/cbl/lib/src/replication/proxy_replicator.dart
@@ -10,7 +10,6 @@ import '../service/cbl_service.dart';
 import '../service/cbl_service_api.dart';
 import '../service/proxy_object.dart';
 import '../support/edition.dart';
-import '../support/encoding.dart';
 import '../support/errors.dart';
 import '../support/listener_token.dart';
 import '../support/resource.dart';
@@ -79,7 +78,7 @@ class ProxyReplicator extends ProxyObject
     try {
       final objectId = await database.channel.call(CreateReplicator(
         databaseId: database.objectId,
-        propertiesFormat: EncodingFormat.fleece,
+        propertiesFormat: database.encodingFormat,
         target: target,
         replicatorType: config.replicatorType,
         continuous: config.continuous,

--- a/packages/cbl/lib/src/service/cbl_service.dart
+++ b/packages/cbl/lib/src/service/cbl_service.dart
@@ -685,18 +685,11 @@ class CblService {
           propertiesFormat: propertiesFormat,
         );
 
-        final result = await channel.call(CallReplicationFilter(
+        return channel.call(CallReplicationFilter(
           filterId: filterId,
           state: state,
           flags: flags,
         ));
-
-        // The document must not be GCed because the `DocumentState` that
-        // is sent to the conflict resolver contains the address of the native
-        // document properties.
-        cblReachabilityFence(document);
-
-        return result;
       };
 
   ConflictResolver _createConflictResolver(
@@ -720,12 +713,6 @@ class CblService {
           localState: localState,
           remoteState: remoteState,
         ));
-
-        // The documents must not be GCed because the `DocumentState`s that
-        // are sent to the conflict resolver contain the addresses of the native
-        // documents properties.
-        cblReachabilityFence(localDocument);
-        cblReachabilityFence(remoteDocument);
 
         if (resolvedState != null) {
           final stateToExistingDocument = {

--- a/packages/cbl/lib/src/service/cbl_service.dart
+++ b/packages/cbl/lib/src/service/cbl_service.dart
@@ -7,6 +7,7 @@ import '../database/database.dart';
 import '../database/database_configuration.dart';
 import '../database/ffi_database.dart';
 import '../document/document.dart';
+import '../document/ffi_document.dart';
 import '../document/proxy_document.dart';
 import '../query/ffi_query.dart';
 import '../query/index/index.dart';
@@ -393,8 +394,8 @@ class CblService {
 
     _objectRegistry.addObject(document);
 
-    return _createDocumentState(
-      document,
+    return document.createState(
+      withProperties: true,
       propertiesFormat: request.propertiesFormat,
     );
   }
@@ -412,11 +413,11 @@ class CblService {
       return null;
     }
 
-    document.setEncodedProperties(request.state.properties!);
+    document.setEncodedProperties(request.state.properties!.encodedData!);
 
     final success = database.saveDocument(document, request.concurrencyControl);
 
-    return success ? _createDocumentState(document) : null;
+    return success ? document.createState(withProperties: false) : null;
   }
 
   Future<DocumentState?> _deleteDocument(DeleteDocument request) async {
@@ -435,7 +436,7 @@ class CblService {
     final success =
         database.deleteDocument(document, request.concurrencyControl);
 
-    return success ? _createDocumentState(document) : null;
+    return success ? document.createState(withProperties: false) : null;
   }
 
   void _purgeDocument(PurgeDocument request) =>
@@ -532,7 +533,7 @@ class CblService {
   int _executeQuery(ExecuteQuery request) =>
       _getQueryById(request.queryId).execute();
 
-  Stream<EncodedData> _getQueryResultSet(GetQueryResultSet request) =>
+  Stream<TransferableValue> _getQueryResultSet(GetQueryResultSet request) =>
       _getQueryById(request.queryId).takeResultSet(request.resultSetId);
 
   void _addQueryChangeListener(AddQueryChangeListener request) {
@@ -553,6 +554,11 @@ class CblService {
       target = DatabaseEndpoint(_getDatabaseById(target.databaseId));
     }
 
+    T Function(int) createCallback<T>(
+      T Function(int, {required EncodingFormat? propertiesFormat}) fn,
+    ) =>
+        (id) => fn(id, propertiesFormat: request.propertiesFormat);
+
     final config = ReplicatorConfiguration(
       database: db,
       target: target,
@@ -563,19 +569,12 @@ class CblService {
       headers: request.headers,
       channels: request.channels,
       documentIds: request.documentIds,
-      pushFilter: request.pushFilterId?.let((id) => _createReplicatorFilter(
-            id,
-            propertiesFormat: request.propertiesFormat,
-          )),
-      pullFilter: request.pullFilterId?.let((id) => _createReplicatorFilter(
-            id,
-            propertiesFormat: request.propertiesFormat,
-          )),
-      conflictResolver:
-          request.conflictResolverId?.let((id) => _createConflictResolver(
-                id,
-                propertiesFormat: request.propertiesFormat,
-              )),
+      pushFilter:
+          request.pushFilterId?.let(createCallback(_createReplicatorFilter)),
+      pullFilter:
+          request.pullFilterId?.let(createCallback(_createReplicatorFilter)),
+      conflictResolver: request.conflictResolverId
+          ?.let(createCallback(_createConflictResolver)),
       enableAutoPurge: request.enableAutoPurge,
       heartbeat: request.heartbeat,
       maxAttempts: request.maxAttempts,
@@ -646,23 +645,6 @@ class CblService {
         indexes: database.indexes,
       );
 
-  Future<DocumentState> _createDocumentState(
-    DelegateDocument document, {
-    EncodingFormat? propertiesFormat,
-  }) async {
-    EncodedData? properties;
-    if (propertiesFormat != null) {
-      properties = await document.encodeProperties(format: propertiesFormat);
-    }
-
-    return DocumentState(
-      id: document.id,
-      revisionId: document.revisionId,
-      sequence: document.sequence,
-      properties: properties,
-    );
-  }
-
   MutableDelegateDocument? _getDocumentForUpdate(
     SyncDatabase database,
     DocumentState state,
@@ -695,34 +677,55 @@ class CblService {
 
   ReplicationFilter _createReplicatorFilter(
     int filterId, {
-    required EncodingFormat propertiesFormat,
+    required EncodingFormat? propertiesFormat,
   }) =>
       (document, flags) async {
-        final state = await (document as DelegateDocument)
-            .getState(propertiesFormat: propertiesFormat);
+        final state = await (document as DelegateDocument).createState(
+          withProperties: true,
+          propertiesFormat: propertiesFormat,
+        );
 
-        return channel.call(CallReplicationFilter(
+        final result = await channel.call(CallReplicationFilter(
           filterId: filterId,
           state: state,
           flags: flags,
         ));
+
+        // The document must not be GCed because the `DocumentState` that
+        // is sent to the conflict resolver contains the address of the native
+        // document properties.
+        cblReachabilityFence(document);
+
+        return result;
       };
 
   ConflictResolver _createConflictResolver(
     int resolverId, {
-    required EncodingFormat propertiesFormat,
+    required EncodingFormat? propertiesFormat,
   }) =>
       ConflictResolver.from((conflict) async {
-        final localState = await (conflict.localDocument as DelegateDocument?)
-            ?.getState(propertiesFormat: propertiesFormat);
-        final remoteState = await (conflict.remoteDocument as DelegateDocument?)
-            ?.getState(propertiesFormat: propertiesFormat);
+        final localDocument = conflict.localDocument as DelegateDocument?;
+        final remoteDocument = conflict.remoteDocument as DelegateDocument?;
+        final localState = await localDocument?.createState(
+          withProperties: true,
+          propertiesFormat: propertiesFormat,
+        );
+        final remoteState = await remoteDocument?.createState(
+          withProperties: true,
+          propertiesFormat: propertiesFormat,
+        );
 
         final resolvedState = await channel.call(CallConflictResolver(
           resolverId: resolverId,
           localState: localState,
           remoteState: remoteState,
         ));
+
+        // The documents must not be GCed because the `DocumentState`s that
+        // are sent to the conflict resolver contain the addresses of the native
+        // documents properties.
+        cblReachabilityFence(localDocument);
+        cblReachabilityFence(remoteDocument);
 
         if (resolvedState != null) {
           final stateToExistingDocument = {
@@ -766,7 +769,7 @@ class _Query {
   _Query(this.query, this.resultEncoding);
 
   final FfiQuery query;
-  final EncodingFormat resultEncoding;
+  final EncodingFormat? resultEncoding;
 
   int _nextResultSetId = 0;
   final _resultSets = <int, ResultSet>{};
@@ -779,12 +782,21 @@ class _Query {
     return id;
   }
 
-  Stream<EncodedData> takeResultSet(int id) =>
+  Stream<TransferableValue> takeResultSet(int id) =>
       _resultSetStream(_resultSets.remove(id)!);
 
-  Stream<EncodedData> _resultSetStream(ResultSet resultSet) =>
-      resultSet.asStream().map((result) =>
-          (result as ResultImpl).encodeColumnValues(resultEncoding));
+  Stream<TransferableValue> _resultSetStream(ResultSet resultSet) =>
+      resultSet.asStream().map((result) {
+        final resultImpl = result as ResultImpl;
+        final resultEncoding = this.resultEncoding;
+        if (resultEncoding != null) {
+          return TransferableValue.fromEncodedData(
+            resultImpl.encodeColumnValues(resultEncoding),
+          );
+        } else {
+          return TransferableValue.fromValue(resultImpl.columnValuesArray!);
+        }
+      });
 
   ListenerToken addChangeListener(void Function(int resultSetId) listener) =>
       query.addChangeListener((change) {
@@ -803,10 +815,22 @@ extension on ObjectRegistry {
 }
 
 extension on DelegateDocument {
-  Future<DocumentState> getState({
-    required EncodingFormat propertiesFormat,
+  Future<DocumentState> createState({
+    required bool withProperties,
+    EncodingFormat? propertiesFormat,
   }) async {
-    final properties = await encodeProperties(format: propertiesFormat);
+    TransferableValue? properties;
+    if (withProperties) {
+      if (propertiesFormat != null) {
+        properties = TransferableValue.fromEncodedData(
+          await encodeProperties(format: propertiesFormat),
+        );
+      } else {
+        properties = TransferableValue.fromValue(
+          (delegate as FfiDocumentDelegate).propertiesDict,
+        );
+      }
+    }
 
     return DocumentState(
       id: id,

--- a/packages/cbl/lib/src/service/cbl_service_api.dart
+++ b/packages/cbl/lib/src/service/cbl_service_api.dart
@@ -1,18 +1,22 @@
 // ignore: lines_longer_than_80_chars
 // ignore_for_file: prefer_constructors_over_static_methods,prefer_void_to_null
 
+import 'dart:ffi';
+
 import 'package:cbl_ffi/cbl_ffi.dart';
 import 'package:meta/meta.dart';
 
 import '../database.dart';
 import '../database/database_configuration.dart';
 import '../errors.dart';
+import '../fleece/containers.dart';
 import '../replication/authenticator.dart';
 import '../replication/configuration.dart';
 import '../replication/document_replication.dart';
 import '../replication/endpoint.dart';
 import '../replication/replicator.dart';
 import '../support/encoding.dart';
+import '../support/ffi.dart';
 import '../support/utils.dart';
 import '../tracing.dart';
 import 'channel.dart';
@@ -173,6 +177,11 @@ SerializationRegistry cblServiceSerializationRegistry() =>
       )
 
       // CblService specific types
+      ..addSerializableCodec(
+        'TransferableValue',
+        TransferableValue.deserialize,
+        isIsolatePortSafe: false,
+      )
       ..addSerializableCodec('DatabaseState', DatabaseState.deserialize)
       ..addSerializableCodec(
         'DocumentState',
@@ -717,7 +726,7 @@ class GetDocument extends Request<DocumentState?> {
 
   final int databaseId;
   final String documentId;
-  final EncodingFormat propertiesFormat;
+  final EncodingFormat? propertiesFormat;
 
   @override
   StringMap serialize(SerializationContext context) => {
@@ -730,7 +739,7 @@ class GetDocument extends Request<DocumentState?> {
       GetDocument(
         map.getAs('databaseId'),
         map.getAs('documentId'),
-        context.deserializeAs(map['propertiesFormat'])!,
+        context.deserializeAs(map['propertiesFormat']),
       );
 }
 
@@ -1218,7 +1227,7 @@ class CreateQuery implements Request<QueryState> {
   final int databaseId;
   final CBLQueryLanguage language;
   final String queryDefinition;
-  final EncodingFormat resultEncoding;
+  final EncodingFormat? resultEncoding;
 
   @override
   StringMap serialize(SerializationContext context) => {
@@ -1236,7 +1245,7 @@ class CreateQuery implements Request<QueryState> {
         databaseId: map.getAs('databaseId'),
         language: context.deserializeAs(map['language'])!,
         queryDefinition: map.getAs('queryDefinition'),
-        resultEncoding: context.deserializeAs(map['resultEncoding'])!,
+        resultEncoding: context.deserializeAs(map['resultEncoding']),
       );
 }
 
@@ -1299,7 +1308,7 @@ class ExecuteQuery implements Request<int> {
       ExecuteQuery(queryId: map.getAs('queryId'));
 }
 
-class GetQueryResultSet implements Request<EncodedData> {
+class GetQueryResultSet implements Request<TransferableValue> {
   GetQueryResultSet({
     required this.queryId,
     required this.resultSetId,
@@ -1414,7 +1423,7 @@ class CreateReplicator extends Request<int> {
   });
 
   final int databaseId;
-  final EncodingFormat propertiesFormat;
+  final EncodingFormat? propertiesFormat;
   final Endpoint target;
   final ReplicatorType replicatorType;
   final bool continuous;
@@ -1458,7 +1467,7 @@ class CreateReplicator extends Request<int> {
   ) =>
       CreateReplicator(
         databaseId: map.getAs('databaseId'),
-        propertiesFormat: context.deserializeAs(map['propertiesFormat'])!,
+        propertiesFormat: context.deserializeAs(map['propertiesFormat']),
         target: context.deserializePolymorphic(map['target'])!,
         replicatorType: context.deserializeAs(map['replicatorType'])!,
         continuous: map.getAs('continuous'),
@@ -1754,6 +1763,45 @@ class ReplicatorPendingDocumentIds extends Request<List<String>> {
 
 // === Responses ===============================================================
 
+class TransferableValue implements Serializable {
+  TransferableValue._(this.encodedData, this.value) : _valueAddress = null;
+
+  TransferableValue.fromEncodedData(EncodedData this.encodedData)
+      : value = null,
+        _valueAddress = null;
+
+  TransferableValue.fromValue(Value this.value)
+      : encodedData = null,
+        _valueAddress = value.pointer.address {
+    cblBindings.fleece.value.retain(value!.pointer);
+  }
+
+  final EncodedData? encodedData;
+  final Value? value;
+  final int? _valueAddress;
+
+  @override
+  StringMap serialize(SerializationContext context) => {
+        'encodedData': context.serialize(encodedData),
+        'fleeceValueAddress': _valueAddress,
+      };
+
+  static TransferableValue deserialize(
+    StringMap map,
+    SerializationContext context,
+  ) {
+    final encodedData = context.deserializeAs<EncodedData>(map['encodedData']);
+
+    Value? value;
+    final valueAddress = map.getAs<int?>('fleeceValueAddress');
+    if (valueAddress != null) {
+      value = Value.fromPointer(Pointer.fromAddress(valueAddress), adopt: true);
+    }
+
+    return TransferableValue._(encodedData, value);
+  }
+}
+
 class DatabaseState implements Serializable {
   DatabaseState({
     required this.id,
@@ -1803,7 +1851,7 @@ class DocumentState implements Serializable {
   final String id;
   final String? revisionId;
   final int sequence;
-  final EncodedData? properties;
+  final TransferableValue? properties;
 
   @override
   bool operator ==(Object other) =>

--- a/packages/cbl/lib/src/service/cbl_service_api.dart
+++ b/packages/cbl/lib/src/service/cbl_service_api.dart
@@ -1783,7 +1783,7 @@ class TransferableValue implements Serializable {
   @override
   StringMap serialize(SerializationContext context) => {
         'encodedData': context.serialize(encodedData),
-        'fleeceValueAddress': _valueAddress,
+        'valueAddress': _valueAddress,
       };
 
   static TransferableValue deserialize(
@@ -1793,7 +1793,7 @@ class TransferableValue implements Serializable {
     final encodedData = context.deserializeAs<EncodedData>(map['encodedData']);
 
     Value? value;
-    final valueAddress = map.getAs<int?>('fleeceValueAddress');
+    final valueAddress = map.getAs<int?>('valueAddress');
     if (valueAddress != null) {
       value = Value.fromPointer(Pointer.fromAddress(valueAddress), adopt: true);
     }

--- a/packages/cbl_e2e_tests/lib/src/utils/database_utils.dart
+++ b/packages/cbl_e2e_tests/lib/src/utils/database_utils.dart
@@ -8,6 +8,7 @@ import 'package:cbl/src/service/cbl_service_api.dart';
 import 'package:cbl/src/service/cbl_worker.dart';
 import 'package:cbl/src/service/channel.dart';
 import 'package:cbl/src/service/serialization/json_packet_codec.dart';
+import 'package:cbl/src/support/encoding.dart';
 import 'package:cbl/src/support/utils.dart';
 import 'package:stream_channel/stream_channel.dart';
 
@@ -115,6 +116,7 @@ Future<AsyncDatabase> openAsyncTestDatabase({
       name: name,
       config: config,
       client: _sharedIsolateClient(isolate),
+      encodingFormat: EncodingFormat.fleece,
     );
   }
 

--- a/packages/cbl_e2e_tests/lib/src/utils/database_utils.dart
+++ b/packages/cbl_e2e_tests/lib/src/utils/database_utils.dart
@@ -116,7 +116,10 @@ Future<AsyncDatabase> openAsyncTestDatabase({
       name: name,
       config: config,
       client: _sharedIsolateClient(isolate),
-      encodingFormat: EncodingFormat.fleece,
+      encodingFormat:
+          // To cover both transferring encoded data and Fleece values we use
+          // different encoding formats for the two worker isolate targets.
+          isolate == Isolate.worker ? EncodingFormat.fleece : null,
     );
   }
 

--- a/packages/cbl_ffi/lib/src/fleece.dart
+++ b/packages/cbl_ffi/lib/src/fleece.dart
@@ -597,6 +597,11 @@ typedef _FLValue_IsEqual = bool Function(
   Pointer<FLValue> v2,
 );
 
+typedef _FLValue_Retain = Pointer<FLValue> Function(Pointer<FLValue> value);
+
+typedef _FLValue_Release_C = Void Function(Pointer<FLValue> value);
+typedef _FLValue_Release = void Function(Pointer<FLValue> value);
+
 typedef _FLValue_ToJSONX_C = FLStringResult Function(
   Pointer<FLValue> value,
   Bool json5,
@@ -664,6 +669,14 @@ class ValueBindings extends Bindings {
       'FLValue_IsEqual',
       isLeaf: useIsLeaf,
     );
+    _retain = libs.cbl.lookupFunction<_FLValue_Retain, _FLValue_Retain>(
+      'FLValue_Retain',
+      isLeaf: useIsLeaf,
+    );
+    _release = libs.cbl.lookupFunction<_FLValue_Release_C, _FLValue_Release>(
+      'FLValue_Release',
+      isLeaf: useIsLeaf,
+    );
     _toJson = libs.cbl.lookupFunction<_FLValue_ToJSONX_C, _FLValue_ToJSONX>(
       'FLValue_ToJSONX',
       isLeaf: useIsLeaf,
@@ -683,6 +696,8 @@ class ValueBindings extends Bindings {
   late final _FLValue_AsData _asData;
   late final _FLValue_ToString _scalarToString;
   late final _FLValue_IsEqual _isEqual;
+  late final _FLValue_Retain _retain;
+  late final _FLValue_Release _release;
   late final _FLValue_ToJSONX _toJson;
 
   void bindToDartObject(
@@ -723,6 +738,10 @@ class ValueBindings extends Bindings {
       _scalarToString(value).toDartStringAndRelease();
 
   bool isEqual(Pointer<FLValue> a, Pointer<FLValue> b) => _isEqual(a, b);
+
+  void retain(Pointer<FLValue> value) => _retain(value);
+
+  void release(Pointer<FLValue> value) => _release(value);
 
   String toJSONX(
     Pointer<FLValue> value, {


### PR DESCRIPTION
This change adds `TransferableValue`, which can be used to transfer `EncodedData` or a Fleece `Value` by its address between isolates.
    
When isolates are in the same process (as is the case for `WorkerDatabase`), a `TransferableValue` does not require copying.
    
Closes #309