### PR TITLE
fix: use own `SharedKeysTable` for each `ResultSet`

### DIFF
--- a/packages/cbl/lib/src/document/common.dart
+++ b/packages/cbl/lib/src/document/common.dart
@@ -8,6 +8,7 @@ import '../database.dart';
 import '../database/database_base.dart';
 import '../fleece/containers.dart' as fl;
 import '../fleece/decoder.dart';
+import '../fleece/dict_key.dart';
 import '../fleece/encoder.dart';
 import '../fleece/integration/integration.dart';
 import '../support/ffi.dart';
@@ -104,11 +105,15 @@ abstract class MCollectionWrapper {
 }
 
 class DatabaseMContext extends MContext {
-  DatabaseMContext(this.database)
-      : super(
-          dictKeys: database?.dictKeys,
-          sharedKeysTable: database?.sharedKeysTable,
-          sharedStringsTable: SharedStringsTable(),
+  DatabaseMContext({
+    this.database,
+    DictKeys? dictKeys,
+    SharedKeysTable? sharedKeysTable,
+    SharedStringsTable? sharedStringsTable,
+  }) : super(
+          dictKeys: dictKeys,
+          sharedKeysTable: sharedKeysTable,
+          sharedStringsTable: sharedStringsTable,
         );
 
   final DatabaseBase? database;

--- a/packages/cbl/lib/src/query/ffi_query.dart
+++ b/packages/cbl/lib/src/query/ffi_query.dart
@@ -216,7 +216,7 @@ class FfiResultSet with IterableMixin<Result> implements SyncResultSet {
           pointer,
           debugCreator: debugCreator,
         ),
-        _context = DatabaseMContext(query.database);
+        _context = createResultSetMContext(query.database!);
 
   final List<String> _columnNames;
   final ResultSetIterator _iterator;

--- a/packages/cbl/lib/src/query/proxy_query.dart
+++ b/packages/cbl/lib/src/query/proxy_query.dart
@@ -4,7 +4,6 @@ import 'package:cbl_ffi/cbl_ffi.dart';
 import 'package:synchronized/synchronized.dart';
 
 import '../database/proxy_database.dart';
-import '../document/common.dart';
 import '../fleece/encoder.dart';
 import '../service/cbl_service_api.dart';
 import '../service/proxy_object.dart';
@@ -220,7 +219,7 @@ class ProxyResultSet extends ResultSet {
             event,
             // Every result needs its own context, because each result is
             // encoded independently.
-            context: DatabaseMContext(_query.database),
+            context: createResultSetMContext(_query.database!),
             columnNames: _query._columnNames,
           ))
       .transform(ResourceStreamTransformer(parent: _query, blocking: true));

--- a/packages/cbl/lib/src/query/result_set.dart
+++ b/packages/cbl/lib/src/query/result_set.dart
@@ -1,5 +1,8 @@
 import 'dart:async';
 
+import '../database/database_base.dart';
+import '../document/common.dart';
+import '../fleece/decoder.dart';
 import 'query.dart';
 import 'result.dart';
 
@@ -24,3 +27,21 @@ abstract class ResultSet {
 /// {@category Query}
 abstract class SyncResultSet
     implements ResultSet, Iterable<Result>, Iterator<Result> {}
+
+/// Creates a [DatabaseMContext] for use in [ResultSet] implementations.
+///
+/// Result sets don't use the shared keys of the database and so must not used
+/// the [SharedKeysTable] of the database.
+/// See SQLiteQuery.cc for more information.
+/// https://github.com/couchbase/couchbase-lite-core/blob/733eecb4fc73a05ce35bf458703dac2d7382c296/LiteCore/Query/SQLiteQuery.cc#L514-L524
+///
+/// A bug was the result of using the databases shared keys table in the result
+/// set.
+/// https://github.com/cbl-dart/cbl-dart/issues/322
+DatabaseMContext createResultSetMContext(DatabaseBase database) =>
+    DatabaseMContext(
+      database: database,
+      dictKeys: database.dictKeys,
+      sharedKeysTable: SharedKeysTable(),
+      sharedStringsTable: SharedStringsTable(),
+    );


### PR DESCRIPTION
Fixes #322