### PR TITLE
fix: keep `AsyncCallback` reachable in `close`

### DIFF
--- a/packages/cbl/lib/src/support/async_callback.dart
+++ b/packages/cbl/lib/src/support/async_callback.dart
@@ -97,7 +97,7 @@ class AsyncCallback implements NativeResource<CBLDartAsyncCallback> {
     _debugLog('closing');
     _closed = true;
     _bindings.close(native.pointer);
-    cblReachabilityFence(native);
+    cblReachabilityFence(this);
     _receivePort.close();
   }
 


### PR DESCRIPTION
The reachability fence in `AsyncCallback.close` was keeping `native` alive,
which in this case is just a wrapper for the pointer and not the Dart object that is
used for finalization. Now `this` is used to ensure that the `AsyncCallback`
finalizer is not running while `_bindings.close` is.