### PR TITLE
feat: support sharing mutable collections with multiple documents

### DIFF
--- a/packages/cbl/lib/src/document/common.dart
+++ b/packages/cbl/lib/src/document/common.dart
@@ -86,18 +86,21 @@ abstract class FleeceEncodable {
   FutureOr<void> encodeTo(FleeceEncoder encoder);
 }
 
-class FleeceEncoderContext {
+class FleeceEncoderContext implements DictKeysProvider {
   FleeceEncoderContext({
     this.database,
     this.encodeQueryParameter = false,
     this.saveExternalData = false,
   });
 
-  final Database? database;
+  final DatabaseBase? database;
 
   final bool encodeQueryParameter;
 
   final bool saveExternalData;
+
+  @override
+  DictKeys? get dictKeys => database?.dictKeys;
 }
 
 abstract class MCollectionWrapper {
@@ -107,13 +110,24 @@ abstract class MCollectionWrapper {
 class DatabaseMContext extends MContext {
   DatabaseMContext({
     this.database,
+    Object? data,
     DictKeys? dictKeys,
     SharedKeysTable? sharedKeysTable,
     SharedStringsTable? sharedStringsTable,
   }) : super(
+          data: data,
           dictKeys: dictKeys,
           sharedKeysTable: sharedKeysTable,
           sharedStringsTable: sharedStringsTable,
+        );
+
+  DatabaseMContext.from(DatabaseMContext other, {Object? data})
+      : this(
+          database: other.database,
+          data: data,
+          dictKeys: other.dictKeys,
+          sharedKeysTable: other.sharedKeysTable,
+          sharedStringsTable: other.sharedStringsTable,
         );
 
   final DatabaseBase? database;
@@ -229,7 +243,7 @@ bool valueWouldChange(
   final flValue = oldValue.value;
   if (flValue != null) {
     final valueType = _valueBinds.getType(flValue);
-    cblReachabilityFence(container.dataOwner);
+    cblReachabilityFence(container.context);
     if (valueType == FLValueType.array || valueType == FLValueType.dict) {
       return true;
     }

--- a/packages/cbl/lib/src/document/ffi_document.dart
+++ b/packages/cbl/lib/src/document/ffi_document.dart
@@ -89,10 +89,9 @@ class FfiDocumentDelegate extends DocumentDelegate
       .setProperties(native.pointer.cast(), value.cast());
 
   @override
-  MRoot createMRoot(MContext context, {required bool isMutable}) {
-    final result = MRoot.fromValue(
-      _nativeProperties,
-      context: context,
+  MRoot createMRoot(DelegateDocument document, {required bool isMutable}) {
+    final result = MRoot.fromContext(
+      DocumentMContext(document, data: FleeceValueObject(_nativeProperties)),
       isMutable: isMutable,
     );
     cblReachabilityFence(native);

--- a/packages/cbl/lib/src/document/proxy_document.dart
+++ b/packages/cbl/lib/src/document/proxy_document.dart
@@ -2,11 +2,11 @@ import 'package:cbl_ffi/cbl_ffi.dart';
 
 import '../database/proxy_database.dart';
 import '../fleece/containers.dart';
-import '../fleece/integration/context.dart';
 import '../fleece/integration/root.dart';
 import '../service/cbl_service_api.dart';
 import '../service/proxy_object.dart';
 import '../support/encoding.dart';
+import '../support/native_object.dart';
 import 'document.dart';
 
 class ProxyDocumentDelegate extends DocumentDelegate with ProxyObjectMixin {
@@ -52,21 +52,25 @@ class ProxyDocumentDelegate extends DocumentDelegate with ProxyObjectMixin {
   final Dict? _propertiesDict;
 
   @override
-  MRoot createMRoot(MContext context, {required bool isMutable}) {
+  MRoot createMRoot(DelegateDocument document, {required bool isMutable}) {
     final propertiesDict = _propertiesDict;
     if (propertiesDict != null) {
-      final result = MRoot.fromValue(
-        propertiesDict.pointer,
-        context: context,
+      final result = MRoot.fromContext(
+        DocumentMContext(
+          document,
+          data: FleeceValueObject(propertiesDict.pointer),
+        ),
         isMutable: isMutable,
       );
       cblReachabilityFence(propertiesDict);
       return result;
     }
 
-    return MRoot.fromData(
-      properties!.toFleece().toSliceResult(),
-      context: context,
+    return MRoot.fromContext(
+      DocumentMContext(
+        document,
+        data: Doc.fromResultData(properties!.toFleece(), FLTrust.trusted),
+      ),
       isMutable: isMutable,
     );
   }

--- a/packages/cbl/lib/src/fleece/dict_key.dart
+++ b/packages/cbl/lib/src/fleece/dict_key.dart
@@ -101,6 +101,12 @@ class _OptimizedDictKey extends DictKey {
   }
 }
 
+/// An object which might be able to provide [DictKeys].
+abstract class DictKeysProvider {
+  /// The [DictKeys] associated with this object, if available.
+  DictKeys? get dictKeys;
+}
+
 /// A provider of [DictKey]s.
 ///
 /// A [DictKeys] instance must only be used for Fleece data that shares the same

--- a/packages/cbl/lib/src/fleece/integration/array.dart
+++ b/packages/cbl/lib/src/fleece/integration/array.dart
@@ -52,7 +52,7 @@ class MArray extends MCollection {
     var value = _values[index];
     if (value == null) {
       value = _values[index] = _loadMValue(index);
-      cblReachabilityFence(dataOwner);
+      cblReachabilityFence(context);
     }
 
     return value;
@@ -67,7 +67,7 @@ class MArray extends MCollection {
     }
 
     mutate();
-    (_values[index] ??= MValue.empty()).setNative(native, this);
+    (_values[index] ??= MValue.empty()).setNative(native);
 
     return true;
   }
@@ -84,7 +84,7 @@ class MArray extends MCollection {
     }
 
     mutate();
-    _values.insert(index, MValue.empty()..setNative(native, this));
+    _values.insert(index, MValue.empty()..setNative(native));
 
     return true;
   }
@@ -159,7 +159,7 @@ class MArray extends MCollection {
       yield _values[i] ??= _loadMValue(i);
     }
 
-    cblReachabilityFence(dataOwner);
+    cblReachabilityFence(context);
   }
 
   void _populateValues() {
@@ -175,7 +175,7 @@ class MArray extends MCollection {
       i++;
     }
 
-    cblReachabilityFence(dataOwner);
+    cblReachabilityFence(context);
   }
 
   MValue _loadMValue(int index) =>

--- a/packages/cbl/lib/src/fleece/integration/collection.dart
+++ b/packages/cbl/lib/src/fleece/integration/collection.dart
@@ -11,87 +11,59 @@ import 'value.dart';
 abstract class MCollection {
   MCollection({
     MContext? context,
-    bool isMutable = true,
-    this.dataOwner,
+    this.isMutable = true,
   })  : _context = context,
-        _isMutable = isMutable,
-        hasMutableChildren = isMutable,
         _isMutated = true;
 
   MCollection.asCopy(
     MCollection original, {
-    required bool isMutable,
+    required this.isMutable,
   })  : _context = original._context,
-        dataOwner = original.dataOwner,
-        _isMutable = isMutable,
-        hasMutableChildren = isMutable,
         _isMutated = true;
 
   MCollection.asChild(
     MValue slot,
     MCollection parent, {
-    required bool isMutable,
-  })  : dataOwner = parent.dataOwner,
-        _isMutable = isMutable,
-        hasMutableChildren = isMutable,
-        _isMutated = slot.isMutated {
-    updateParent(slot, parent);
-  }
+    required this.isMutable,
+  })  : _context = parent._context,
+        _slot = slot,
+        _parent = parent,
+        _isMutated = slot.isMutated;
 
-  MContext get context => _context ?? const NoopMContext();
-  MContext? _context;
-
-  /// An object that owns the Fleece data that this collection is contained in.
+  /// The context which this collection uses when reading Fleece data.
   ///
-  /// This field is only populated if Fleece data is being used.
+  /// The context owns the Fleece data that this collection is based on.
   ///
-  /// Collections must ensure that this object stays reachable while accessing
-  /// Fleece data by using a [cblReachabilityFence].
-  final Object? dataOwner;
+  /// Collections must ensure that this it's context stays reachable while
+  /// accessing Fleece data by using a [cblReachabilityFence].
+  MContext get context => _context ?? const MContext();
+  final MContext? _context;
 
   MValue? _slot;
 
   MCollection? get parent => _parent;
   MCollection? _parent;
 
-  Iterable<MValue> get values;
+  final bool isMutable;
 
-  bool get isMutable => _isMutable;
-  final bool _isMutable;
-
-  final bool hasMutableChildren;
+  bool get hasMutableChildren => isMutable;
 
   bool get isMutated => _isMutated;
   bool _isMutated;
 
-  bool get isEncoding => _isEncoding || (_parent?.isEncoding ?? false);
-  bool _isEncoding = false;
+  Iterable<MValue> get values;
 
-  FutureOr<void> encodeTo(FleeceEncoder encoder) {
-    FutureOr<void> encode() => performEncodeTo(encoder).then((_) {
-          // We keep the data owner alive until the end of encoding, so that
-          // MCollections can safely use Fleece data during encoding.
-          cblReachabilityFence(dataOwner);
-        });
-
-    if (isEncoding) {
-      // Some ancestor is the encoding root so we don't need to do the
-      // bookkeeping again.
-      return encode();
-    } else {
-      // This object is the encoding root and needs to keep track of whether
-      // encoding is ongoing.
-      _isEncoding = true;
-      return finallySyncOrAsync((_) => _isEncoding = false, encode);
-    }
-  }
+  FutureOr<void> encodeTo(FleeceEncoder encoder) =>
+      performEncodeTo(encoder).then((_) {
+        // We keep the context alive until the end of encoding, so that
+        // MCollections can safely use Fleece data during encoding.
+        cblReachabilityFence(context);
+      });
 
   FutureOr<void> performEncodeTo(FleeceEncoder encoder);
 
   @protected
   void mutate() {
-    assert(isMutable && !isEncoding);
-
     if (!_isMutated) {
       _isMutated = true;
       _slot?.mutate();
@@ -99,44 +71,12 @@ abstract class MCollection {
     }
   }
 
-  /// Called when this collection is assigned to a new slot in a parent
-  /// collection or removed from its current parent collection.
-  void updateParent(MValue? slot, MCollection? parent) {
-    assert(slot == null && parent == null || slot != null && parent != null);
-
-    final parentContext = parent?._context;
-
-    // Nothing changed.
-    if (_slot == slot && _parent == parent && _context == parentContext) {
-      return;
-    }
-
-    _slot = slot;
-    _parent = parent;
-
-    if (_isMutated) {
-      _slot?.mutate();
-      _parent?.mutate();
-    }
-
-    _updateContext(parentContext);
-  }
-
-  void _updateContext(MContext? context) {
-    if (context == null || _context == context) {
-      return;
-    }
-
-    assert(
-      _context == null || _context == context,
-      'once set the context of a MCollection cannot change',
-    );
-
-    _context = context;
-
-    // Propagate context to children.
-    for (final value in values) {
-      value.updateParent(this);
+  void setSlot(MValue? newSlot, MValue? oldSlot) {
+    if (_slot == oldSlot) {
+      _slot = newSlot;
+      if (newSlot == null) {
+        _parent = null;
+      }
     }
   }
 }

--- a/packages/cbl/lib/src/fleece/integration/collection.dart
+++ b/packages/cbl/lib/src/fleece/integration/collection.dart
@@ -12,25 +12,24 @@ abstract class MCollection {
   MCollection({
     MContext? context,
     this.isMutable = true,
-  })  : _context = context,
+  })  : context = context ?? const MContext(),
         _isMutated = true;
 
   MCollection.asCopy(
     MCollection original, {
     required this.isMutable,
-  })  : _context = original._context,
+  })  : context = original.context,
         _isMutated = true;
 
   MCollection.asChild(
     MValue slot,
     MCollection parent, {
     required this.isMutable,
-  })  : _context = parent._context,
+  })  : context = parent.context,
         _slot = slot,
         _parent = parent,
         _isMutated = slot.isMutated;
 
-  final MContext? _context;
   MValue? _slot;
   MCollection? _parent;
   final bool isMutable;
@@ -42,7 +41,7 @@ abstract class MCollection {
   ///
   /// Collections must ensure that this it's context stays reachable while
   /// accessing Fleece data by using a [cblReachabilityFence].
-  MContext get context => _context ?? const MContext();
+  final MContext context;
 
   bool get hasMutableChildren => isMutable;
 

--- a/packages/cbl/lib/src/fleece/integration/collection.dart
+++ b/packages/cbl/lib/src/fleece/integration/collection.dart
@@ -30,6 +30,12 @@ abstract class MCollection {
         _parent = parent,
         _isMutated = slot.isMutated;
 
+  final MContext? _context;
+  MValue? _slot;
+  MCollection? _parent;
+  final bool isMutable;
+  bool _isMutated;
+
   /// The context which this collection uses when reading Fleece data.
   ///
   /// The context owns the Fleece data that this collection is based on.
@@ -37,19 +43,10 @@ abstract class MCollection {
   /// Collections must ensure that this it's context stays reachable while
   /// accessing Fleece data by using a [cblReachabilityFence].
   MContext get context => _context ?? const MContext();
-  final MContext? _context;
-
-  MValue? _slot;
-
-  MCollection? get parent => _parent;
-  MCollection? _parent;
-
-  final bool isMutable;
 
   bool get hasMutableChildren => isMutable;
 
   bool get isMutated => _isMutated;
-  bool _isMutated;
 
   Iterable<MValue> get values;
 

--- a/packages/cbl/lib/src/fleece/integration/context.dart
+++ b/packages/cbl/lib/src/fleece/integration/context.dart
@@ -2,7 +2,8 @@ import '../decoder.dart';
 import '../dict_key.dart';
 
 class MContext {
-  MContext({
+  const MContext({
+    this.data,
     DictKeys? dictKeys,
     SharedKeysTable? sharedKeysTable,
     SharedStringsTable? sharedStringsTable,
@@ -11,20 +12,8 @@ class MContext {
         sharedStringsTable =
             sharedStringsTable ?? const NoopSharedStringsTable();
 
+  final Object? data;
   final DictKeys dictKeys;
   final SharedKeysTable sharedKeysTable;
   final SharedStringsTable sharedStringsTable;
-}
-
-class NoopMContext implements MContext {
-  const NoopMContext();
-
-  @override
-  DictKeys get dictKeys => const UnoptimizingDictKeys();
-
-  @override
-  SharedKeysTable get sharedKeysTable => const NoopSharedKeysTable();
-
-  @override
-  SharedStringsTable get sharedStringsTable => const NoopSharedStringsTable();
 }

--- a/packages/cbl/lib/src/fleece/integration/dict.dart
+++ b/packages/cbl/lib/src/fleece/integration/dict.dart
@@ -5,6 +5,7 @@ import 'package:cbl_ffi/cbl_ffi.dart';
 
 import '../../support/utils.dart';
 import '../decoder.dart';
+import '../dict_key.dart';
 import '../encoder.dart';
 import 'collection.dart';
 import 'value.dart';
@@ -27,11 +28,8 @@ class MDict extends MCollection {
         super.asCopy(original, isMutable: isMutable ?? original.isMutable);
 
   MDict.asChild(MValue slot, MCollection parent, int length, {bool? isMutable})
-      :
-        // ignore: cast_nullable_to_non_nullable
-        _dict = slot.value!.cast(),
+      : _dict = slot.value!.cast(),
         _values = {},
-        // ignore: cast_nullable_to_non_nullable
         _length = length,
         _valuesHasAllKeys = false,
         super.asChild(
@@ -64,7 +62,7 @@ class MDict extends MCollection {
     if (value.isEmpty) {
       _length++;
     }
-    value.setNative(native, this);
+    value.setNative(native);
   }
 
   void remove(String key) {
@@ -109,7 +107,7 @@ class MDict extends MCollection {
         _values[key] = MValue.empty();
       }
       cblReachabilityFence(it);
-      cblReachabilityFence(dataOwner);
+      cblReachabilityFence(context);
     }
   }
 
@@ -119,14 +117,21 @@ class MDict extends MCollection {
       encoder.writeValue(_dict!.cast());
     } else {
       return syncOrAsync(() sync* {
-        final dictKeys = context.dictKeys;
+        final extraInfo = encoder.extraInfo;
+        final dictKeys =
+            extraInfo is DictKeysProvider ? extraInfo.dictKeys : null;
+        // ignore: omit_local_variable_types
+        final void Function(String) writeKey = dictKeys != null
+            ? (key) => dictKeys.getKey(key).encodeTo(encoder)
+            : (key) => encoder.writeKey(key);
+
         encoder.beginDict(length);
         for (final entry in iterable) {
           final value = entry.value;
           if (value is _MValueWithKey) {
             encoder.writeKeyValue(value.key);
           } else {
-            dictKeys.getKey(entry.key).encodeTo(encoder);
+            writeKey(entry.key);
           }
           if (value.hasValue) {
             encoder.writeValue(value.value!);
@@ -188,7 +193,7 @@ class MDict extends MCollection {
     _valuesHasAllKeys = true;
 
     cblReachabilityFence(it);
-    cblReachabilityFence(dataOwner);
+    cblReachabilityFence(context);
   }
 
   MValue _getValue(String key) =>
@@ -201,7 +206,7 @@ class MDict extends MCollection {
     }
 
     final flValue = context.dictKeys.getKey(key).getValue(dict);
-    cblReachabilityFence(dataOwner);
+    cblReachabilityFence(context);
     if (flValue == null) {
       return null;
     }

--- a/packages/cbl/lib/src/fleece/integration/dict.dart
+++ b/packages/cbl/lib/src/fleece/integration/dict.dart
@@ -123,7 +123,7 @@ class MDict extends MCollection {
         // ignore: omit_local_variable_types
         final void Function(String) writeKey = dictKeys != null
             ? (key) => dictKeys.getKey(key).encodeTo(encoder)
-            : (key) => encoder.writeKey(key);
+            : encoder.writeKey;
 
         encoder.beginDict(length);
         for (final entry in iterable) {

--- a/packages/cbl/lib/src/fleece/integration/root.dart
+++ b/packages/cbl/lib/src/fleece/integration/root.dart
@@ -3,52 +3,37 @@ import 'dart:ffi';
 
 import 'package:cbl_ffi/cbl_ffi.dart';
 
-import '../../support/ffi.dart';
 import '../../support/native_object.dart';
+import '../containers.dart';
 import '../encoder.dart';
 import 'collection.dart';
 import 'context.dart';
 import 'value.dart';
 
-late final _valueBinds = cblBindings.fleece.value;
-
 class MRoot extends MCollection {
-  MRoot.fromData(
-    SliceResult data, {
-    required MContext context,
+  MRoot.fromContext(
+    MContext context, {
     required bool isMutable,
-  })  : _slot = MValue.withValue(_valueBinds.fromData(data, FLTrust.trusted)!),
-        super(context: context, isMutable: isMutable, dataOwner: data) {
+  })  : _slot = MValue.withValue(context.value),
+        super(context: context, isMutable: isMutable) {
     _slot.updateParent(this);
   }
 
-  MRoot.fromValue(
-    Pointer<FLValue> value, {
+  MRoot.fromNative(
+    Object native, {
     required MContext context,
     required bool isMutable,
-  })  : _slot = MValue.withValue(value),
+  })  : assert(native is! Pointer),
+        assert(context.data == null),
+        _slot = MValue.withNative(native),
         super(
           context: context,
           isMutable: isMutable,
-          dataOwner: FleeceValueObject(value),
         ) {
     _slot.updateParent(this);
   }
 
-  MRoot.fromMValue(
-    MValue value, {
-    required MContext context,
-    required bool isMutable,
-  })  : _slot = value,
-        super(
-          context: context,
-          isMutable: isMutable,
-          dataOwner: value.hasValue ? FleeceValueObject(value.value!) : null,
-        ) {
-    _slot.updateParent(this);
-  }
-
-  late final MValue _slot;
+  final MValue _slot;
 
   @override
   bool get isMutated => _slot.isMutated;
@@ -67,5 +52,18 @@ class MRoot extends MCollection {
     final result = encodeTo(encoder);
     assert(result is! Future);
     return encoder.finish();
+  }
+}
+
+extension on MContext {
+  Pointer<FLValue> get value {
+    final data = this.data;
+    if (data is Doc) {
+      return data.root.pointer;
+    } else if (data is FleeceValueObject) {
+      return data.pointer.cast();
+    } else {
+      throw UnsupportedError('Unsupported MContext.data value: $data');
+    }
   }
 }

--- a/packages/cbl/lib/src/fleece/integration/root.dart
+++ b/packages/cbl/lib/src/fleece/integration/root.dart
@@ -14,7 +14,7 @@ class MRoot extends MCollection {
   MRoot.fromContext(
     MContext context, {
     required bool isMutable,
-  })  : _slot = MValue.withValue(context.value),
+  })  : _slot = MValue.withValue(context.flValue),
         super(context: context, isMutable: isMutable) {
     _slot.updateParent(this);
   }
@@ -56,7 +56,7 @@ class MRoot extends MCollection {
 }
 
 extension on MContext {
-  Pointer<FLValue> get value {
+  Pointer<FLValue> get flValue {
     final data = this.data;
     if (data is Doc) {
       return data.root.pointer;

--- a/packages/cbl/lib/src/fleece/integration/value.dart
+++ b/packages/cbl/lib/src/fleece/integration/value.dart
@@ -11,12 +11,13 @@ import 'delegate.dart';
 
 MDelegate get _delegate => MDelegate.instance!;
 
+final _emptyNative = Object();
+
 class MValue {
   MValue(Pointer<FLValue>? value, Object? native, {required bool hasNative})
       : assert(hasNative || native == null),
         _value = value,
-        _hasNative = hasNative,
-        _native = native;
+        _native = hasNative ? native : _emptyNative;
 
   MValue.empty() : this(null, null, hasNative: false);
 
@@ -24,6 +25,10 @@ class MValue {
       : this(value, null, hasNative: false);
 
   MValue.withNative(Object? native) : this(null, native, hasNative: true);
+
+  MValue._(Pointer<FLValue>? value, Object? native)
+      : _value = value,
+        _native = native;
 
   bool get isEmpty => !hasValue && !hasNative;
 
@@ -36,8 +41,7 @@ class MValue {
   Pointer<FLValue>? get value => _value;
   Pointer<FLValue>? _value;
 
-  bool get hasNative => _hasNative;
-  bool _hasNative;
+  bool get hasNative => _native != _emptyNative;
   Object? _native;
 
   Object? asNative(MCollection parent) {
@@ -49,36 +53,37 @@ class MValue {
       var cacheIt = false;
       final native = _delegate.toNative(this, parent, () => cacheIt = true);
 
-      // We keep the data owner alive while toNative is running, so that
+      // We keep the context alive while toNative is running, so that
       // implementations can safely use _value.
-      cblReachabilityFence(parent.dataOwner);
+      cblReachabilityFence(parent.context);
 
       if (cacheIt) {
         _native = native;
-        _hasNative = true;
       }
       return native;
     }
   }
 
-  void setNative(Object? native, MCollection parent) =>
-      _setNative(native, parent: parent, hasNative: true);
+  void setNative(Object? native) {
+    _setNative(native, hasNative: true);
+    _value = null;
+  }
 
   void setEmpty(MCollection parent) {
     if (isEmpty) {
       return;
     }
+    _setNative(null, hasNative: false);
     _value = null;
-    _setNative(null, parent: parent, hasNative: false);
   }
 
   void mutate() {
     _value = null;
   }
 
-  void updateParent(MCollection parent) => _updateNativeParent(this, parent);
+  void updateParent(MCollection parent) => _nativeChangeSlot(this);
 
-  void removeFromParent() => _updateNativeParent(null, null);
+  void removeFromParent() => _nativeChangeSlot(null);
 
   FutureOr<void> encodeTo(FleeceEncoder encoder) {
     assert(!isEmpty);
@@ -91,38 +96,31 @@ class MValue {
     }
   }
 
-  MValue clone() => MValue(_value, _native, hasNative: _hasNative);
+  MValue clone() => MValue._(_value, _native);
 
-  void _setNative(
-    Object? native, {
-    required MCollection parent,
-    required bool hasNative,
-  }) {
+  void _setNative(Object? native, {required bool hasNative}) {
     assert(
       hasNative || native == null,
       'native must be null when hasNative is false',
     );
 
-    if (_native == native && _hasNative == hasNative) {
-      return;
+    if (hasNative) {
+      if (_native != native) {
+        _nativeChangeSlot(null);
+        _native = native;
+        _nativeChangeSlot(this);
+      }
+    } else if (_native != _emptyNative) {
+      _nativeChangeSlot(null);
+      _native = _emptyNative;
     }
-
-    // Update parent of old native value
-    _updateNativeParent(null, null);
-
-    _hasNative = hasNative;
-    _native = native;
-    mutate();
-
-    // Update parent of new native value
-    _updateNativeParent(this, parent);
   }
 
-  void _updateNativeParent(MValue? slot, MCollection? parent) {
-    if (!_hasNative) {
+  void _nativeChangeSlot(MValue? slot) {
+    if (!hasNative) {
       return;
     }
-    _delegate.collectionFromNative(_native)?.updateParent(slot, parent);
+    _delegate.collectionFromNative(_native)?.setSlot(slot, this);
   }
 
   @override
@@ -131,11 +129,10 @@ class MValue {
       other is MValue &&
           runtimeType == other.runtimeType &&
           _value == other._value &&
-          _hasNative == other._hasNative &&
           _native == other._native;
 
   @override
-  int get hashCode => _value.hashCode ^ _hasNative.hashCode ^ _native.hashCode;
+  int get hashCode => _value.hashCode ^ _native.hashCode;
 
   @override
   String toString() => 'MValue('

--- a/packages/cbl/lib/src/fleece/integration/value.dart
+++ b/packages/cbl/lib/src/fleece/integration/value.dart
@@ -14,11 +14,6 @@ MDelegate get _delegate => MDelegate.instance!;
 final _emptyNative = Object();
 
 class MValue {
-  MValue(Pointer<FLValue>? value, Object? native, {required bool hasNative})
-      : assert(hasNative || native == null),
-        _value = value,
-        _native = hasNative ? native : _emptyNative;
-
   MValue.empty()
       : _value = null,
         _native = _emptyNative;
@@ -35,6 +30,9 @@ class MValue {
       : _value = value,
         _native = native;
 
+  Pointer<FLValue>? _value;
+  Object? _native;
+
   bool get isEmpty => !hasValue && !hasNative;
 
   bool get isNotEmpty => !isEmpty;
@@ -44,10 +42,8 @@ class MValue {
   bool get hasValue => _value != null;
 
   Pointer<FLValue>? get value => _value;
-  Pointer<FLValue>? _value;
 
   bool get hasNative => !identical(_native, _emptyNative);
-  Object? _native;
 
   Object? asNative(MCollection parent) {
     assert(!isEmpty);

--- a/packages/cbl/lib/src/fleece/integration/value.dart
+++ b/packages/cbl/lib/src/fleece/integration/value.dart
@@ -19,12 +19,17 @@ class MValue {
         _value = value,
         _native = hasNative ? native : _emptyNative;
 
-  MValue.empty() : this(null, null, hasNative: false);
+  MValue.empty()
+      : _value = null,
+        _native = _emptyNative;
 
   MValue.withValue(Pointer<FLValue> value)
-      : this(value, null, hasNative: false);
+      : _value = value,
+        _native = _emptyNative;
 
-  MValue.withNative(Object? native) : this(null, native, hasNative: true);
+  MValue.withNative(Object? native)
+      : _value = null,
+        _native = native;
 
   MValue._(Pointer<FLValue>? value, Object? native)
       : _value = value,
@@ -41,7 +46,7 @@ class MValue {
   Pointer<FLValue>? get value => _value;
   Pointer<FLValue>? _value;
 
-  bool get hasNative => _native != _emptyNative;
+  bool get hasNative => !identical(_native, _emptyNative);
   Object? _native;
 
   Object? asNative(MCollection parent) {
@@ -110,7 +115,7 @@ class MValue {
         _native = native;
         _nativeChangeSlot(this);
       }
-    } else if (_native != _emptyNative) {
+    } else if (this.hasNative) {
       _nativeChangeSlot(null);
       _native = _emptyNative;
     }

--- a/packages/cbl/lib/src/query/ffi_query.dart
+++ b/packages/cbl/lib/src/query/ffi_query.dart
@@ -8,7 +8,6 @@ import '../database/ffi_database.dart';
 import '../document/common.dart';
 import '../fleece/containers.dart' as fl;
 import '../fleece/encoder.dart';
-import '../fleece/integration/context.dart';
 import '../support/async_callback.dart';
 import '../support/errors.dart';
 import '../support/ffi.dart';

--- a/packages/cbl/lib/src/query/ffi_query.dart
+++ b/packages/cbl/lib/src/query/ffi_query.dart
@@ -220,7 +220,7 @@ class FfiResultSet with IterableMixin<Result> implements SyncResultSet {
 
   final List<String> _columnNames;
   final ResultSetIterator _iterator;
-  final MContext _context;
+  final DatabaseMContext _context;
   Result? _current;
 
   @override

--- a/packages/cbl_e2e_tests/lib/src/document/array_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/document/array_test.dart
@@ -360,6 +360,35 @@ void main() {
         final array = MutableArray();
         expect(() => array.removeValue(0), throwsRangeError);
       });
+
+      group('from immutable', () {
+        test('share child collection', () {
+          final a = immutableArray([
+            ['a']
+          ]).toMutable();
+          final b = MutableArray([a.value(0)]);
+
+          expect(a.toPlainList(), [
+            ['a']
+          ]);
+          expect(b.toPlainList(), [
+            ['a']
+          ]);
+        });
+
+        test('move child collection', () {
+          final a = immutableArray([
+            ['a']
+          ]).toMutable();
+          final b = MutableArray([a.value(0)]);
+          a.removeValue(0);
+
+          expect(a.toPlainList(), isEmpty);
+          expect(b.toPlainList(), [
+            ['a']
+          ]);
+        });
+      });
     });
   });
 }

--- a/packages/cbl_e2e_tests/lib/src/document/dictionary_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/document/dictionary_test.dart
@@ -304,6 +304,35 @@ void main() {
           'dictionary': {'key': 'value'},
         });
       });
+
+      group('from immutable', () {
+        test('share child collection', () {
+          final a = immutableDictionary({
+            'a': {'k': 'v'}
+          }).toMutable();
+          final b = MutableDictionary({'b': a.value('a')});
+
+          expect(a.toPlainMap(), {
+            'a': {'k': 'v'}
+          });
+          expect(b.toPlainMap(), {
+            'b': {'k': 'v'}
+          });
+        });
+
+        test('move child collection', () {
+          final a = immutableDictionary({
+            'a': {'k': 'v'}
+          }).toMutable();
+          final b = MutableDictionary({'b': a.value('a')});
+          a.removeValue('a');
+
+          expect(a.toPlainMap(), isEmpty);
+          expect(b.toPlainMap(), {
+            'b': {'k': 'v'}
+          });
+        });
+      });
     });
   });
 }

--- a/packages/cbl_e2e_tests/lib/src/document/document_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/document/document_test.dart
@@ -310,6 +310,53 @@ void main() {
         final doc = MutableDocument(data);
         expect(doc.toPlainMap(), data);
       });
+
+      test('add child collection to two documents', () {
+        final docA = MutableDocument();
+        final docB = MutableDocument();
+        final child = MutableDictionary({'a': 'b'});
+
+        // Add child to both documents.
+        docA.setValue(child, key: 'docA');
+        docB.setValue(child, key: 'docB');
+        expect(docA.toPlainMap(), {
+          'docA': {'a': 'b'}
+        });
+        expect(docB.toPlainMap(), {
+          'docB': {'a': 'b'}
+        });
+
+        // Modify the child collection.
+        child.setValue('c', key: 'a');
+        expect(docA.toPlainMap(), {
+          'docA': {'a': 'c'}
+        });
+        expect(docB.toPlainMap(), {
+          'docB': {'a': 'c'}
+        });
+      });
+
+      test('move child collection between two documents', () {
+        final docA = MutableDocument();
+        final docB = MutableDocument();
+        final child = MutableDictionary({'a': 'b'});
+
+        // Add child to both documents and than remove it from docA.
+        docA.setValue(child, key: 'docA');
+        docB.setValue(child, key: 'docB');
+        docA.removeValue('docA');
+        expect(docA.toPlainMap(), <String, Object?>{});
+        expect(docB.toPlainMap(), {
+          'docB': {'a': 'b'}
+        });
+
+        // Modify the child collection.
+        child.setValue('c', key: 'a');
+        expect(docA.toPlainMap(), <String, Object?>{});
+        expect(docB.toPlainMap(), {
+          'docB': {'a': 'c'}
+        });
+      });
     });
 
     test('implements MutableDictionaryInterface for properties', () {

--- a/packages/cbl_e2e_tests/lib/src/document/document_test_utils.dart
+++ b/packages/cbl_e2e_tests/lib/src/document/document_test_utils.dart
@@ -1,12 +1,15 @@
 import 'package:cbl/cbl.dart';
 import 'package:cbl/src/document/array.dart';
 import 'package:cbl/src/document/dictionary.dart';
+import 'package:cbl/src/fleece/containers.dart' show Doc;
 import 'package:cbl/src/fleece/decoder.dart';
 import 'package:cbl/src/fleece/dict_key.dart';
 import 'package:cbl/src/fleece/encoder.dart';
 import 'package:cbl/src/fleece/integration/integration.dart';
+import 'package:cbl_ffi/cbl_ffi.dart';
 
-MContext createTestMContext() => MContext(
+MContext createTestMContext(Object data) => MContext(
+      data: data,
       dictKeys: OptimizingDictKeys(),
       sharedKeysTable: SharedKeysTable(),
       sharedStringsTable: SharedStringsTable(),
@@ -17,9 +20,8 @@ Array immutableArray([List<Object?>? data]) {
   final encoder = FleeceEncoder();
   array.encodeTo(encoder);
   final fleeceData = encoder.finish();
-  final root = MRoot.fromData(
-    fleeceData.toSliceResult(),
-    context: createTestMContext(),
+  final root = MRoot.fromContext(
+    createTestMContext(Doc.fromResultData(fleeceData, FLTrust.trusted)),
     isMutable: false,
   );
   // ignore: cast_nullable_to_non_nullable
@@ -31,9 +33,8 @@ Dictionary immutableDictionary([Map<String, Object?>? data]) {
   final encoder = FleeceEncoder();
   array.encodeTo(encoder);
   final fleeceData = encoder.finish();
-  final root = MRoot.fromData(
-    fleeceData.toSliceResult(),
-    context: createTestMContext(),
+  final root = MRoot.fromContext(
+    createTestMContext(Doc.fromResultData(fleeceData, FLTrust.trusted)),
     isMutable: false,
   );
   // ignore: cast_nullable_to_non_nullable

--- a/packages/cbl_e2e_tests/lib/src/fleece/decoding_benchmark_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/fleece/decoding_benchmark_test.dart
@@ -82,17 +82,15 @@ class FleeceWrapperDecodingBenchmark extends DecodingBenchmark {
   void run() {
     final doc =
         fl.Doc.fromResultData(data, FLTrust.trusted, sharedKeys: sharedKeys);
-    final docRoot = doc.root;
-    final root = MRoot.fromValue(
-      docRoot.pointer,
-      context: MContext(
+    final root = MRoot.fromContext(
+      MContext(
+        data: doc,
         dictKeys: dictKeys,
         sharedKeysTable: sharedKeysTable,
         sharedStringsTable: SharedStringsTable(),
       ),
       isMutable: false,
     );
-    cblReachabilityFence(docRoot);
     (root.asNative! as Array).toPlainList();
   }
 }

--- a/packages/cbl_e2e_tests/lib/src/fleece/encoding_benchmark_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/fleece/encoding_benchmark_test.dart
@@ -46,8 +46,8 @@ class FleeceWrapperEncodingBenchmark extends EncodingBenchmark {
 
   @override
   void run() {
-    final root = MRoot.fromMValue(
-      MValue.withNative(array),
+    final root = MRoot.fromNative(
+      array,
       context: context,
       isMutable: true,
     );

--- a/packages/cbl_e2e_tests/lib/src/fleece/integration_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/fleece/integration_test.dart
@@ -2,6 +2,7 @@
 
 import 'dart:ffi';
 
+import 'package:cbl/src/fleece/containers.dart';
 import 'package:cbl/src/fleece/integration/integration.dart';
 import 'package:cbl_ffi/cbl_ffi.dart';
 
@@ -283,9 +284,8 @@ void main() {
   });
 }
 
-MRoot testMRoot(Object from) => MRoot.fromData(
-      fleeceEncode(from).toSliceResult(),
-      context: MContext(),
+MRoot testMRoot(Object from) => MRoot.fromContext(
+      MContext(data: Doc.fromResultData(fleeceEncode(from), FLTrust.trusted)),
       isMutable: true,
     );
 

--- a/packages/cbl_e2e_tests/lib/src/query/result_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/query/result_test.dart
@@ -1,9 +1,10 @@
 import 'package:cbl/cbl.dart';
+import 'package:cbl/src/database/database_base.dart';
 import 'package:cbl/src/document/array.dart';
 import 'package:cbl/src/document/common.dart';
 import 'package:cbl/src/fleece/encoder.dart';
-import 'package:cbl/src/fleece/integration/integration.dart';
 import 'package:cbl/src/query/result.dart';
+import 'package:cbl/src/query/result_set.dart';
 
 import '../../test_binding_impl.dart';
 import '../fixtures/values.dart';
@@ -237,7 +238,12 @@ Result testResult(List<String> columnNames, List<Object?> columnValues) {
   assert(encodingResult is! Future);
   return ResultImpl.fromValuesData(
     encoder.finish(),
-    context: MContext(),
+    context: createResultSetMContext(MockDatabase()),
     columnNames: columnNames,
   );
+}
+
+class MockDatabase implements DatabaseBase {
+  @override
+  dynamic noSuchMethod(Invocation invocation) {}
 }


### PR DESCRIPTION
Other notable changes:

- Use sentinel for empty native value in `MValue`.
- Retain Fleece data in `MContext`.