### PR TITLE
fix: allow malformed UTF-8 in log and error messages

### DIFF
--- a/packages/cbl_ffi/lib/src/base.dart
+++ b/packages/cbl_ffi/lib/src/base.dart
@@ -421,7 +421,7 @@ class BaseBindings extends Bindings {
   // coverage:ignore-end
 
   String? getErrorMessage(Pointer<CBLError> error) =>
-      _getErrorMessage(error).toDartStringAndRelease();
+      _getErrorMessage(error).toDartStringAndRelease(allowMalformed: true);
 
   void removeListener(Pointer<CBLListenerToken> token) {
     _removeListener(token);

--- a/packages/cbl_ffi/lib/src/fleece.dart
+++ b/packages/cbl_ffi/lib/src/fleece.dart
@@ -110,12 +110,15 @@ class FLStringResult extends Struct {
 
 extension FLStringResultExt on FLStringResult {
   bool get isNull => buf == nullptr;
-  String? toDartStringAndRelease() {
+  String? toDartStringAndRelease({bool allowMalformed = false}) {
     if (isNull) {
       return null;
     }
 
-    final result = buf.cast<Utf8>().toDartString(length: size);
+    final result = utf8.decode(
+      buf.cast<Uint8>().asTypedList(size),
+      allowMalformed: allowMalformed,
+    );
 
     CBLBindings.instance.fleece.slice.releaseStringResult(this);
 

--- a/packages/cbl_ffi/lib/src/logging.dart
+++ b/packages/cbl_ffi/lib/src/logging.dart
@@ -70,7 +70,7 @@ class LogCallbackMessage {
       : this(
           (arguments[0] as int).toLogDomain(),
           (arguments[1] as int).toLogLevel(),
-          utf8.decode(arguments[2] as Uint8List),
+          utf8.decode(arguments[2] as Uint8List, allowMalformed: true),
         );
 
   final CBLLogDomain domain;

--- a/packages/cbl_ffi/lib/src/replicator.dart
+++ b/packages/cbl_ffi/lib/src/replicator.dart
@@ -439,7 +439,7 @@ class DocumentReplicationsCallbackMessage {
           error = CBLErrorException(
             (document[2] as int).toErrorDomain(),
             document[3] as int,
-            utf8.decode(document[4] as Uint8List),
+            utf8.decode(document[4] as Uint8List, allowMalformed: true),
           );
         }
 

--- a/packages/cbl_ffi/lib/src/replicator.dart
+++ b/packages/cbl_ffi/lib/src/replicator.dart
@@ -392,7 +392,7 @@ class ReplicatorStatusCallbackMessage {
     if (status.length > 3) {
       final domain = (status[3] as int).toErrorDomain();
       final errorCode = (status[4] as int).toErrorCode(domain);
-      final message = utf8.decode(status[5] as Uint8List);
+      final message = utf8.decode(status[5] as Uint8List, allowMalformed: true);
       error = CBLErrorException(domain, errorCode, message);
     }
 


### PR DESCRIPTION
Fix for #371 