### PR TITLE
Fix UnsupportedError during initialization

### DIFF
--- a/packages/cbl_flutter/lib/cbl_flutter.dart
+++ b/packages/cbl_flutter/lib/cbl_flutter.dart
@@ -29,7 +29,7 @@ class CouchbaseLiteFlutter {
 Future<InitContext> _context() async {
   final directories = await Future.wait([
     getApplicationSupportDirectory(),
-    if (!Platform.isIOS)
+    if (Platform.isAndroid)
       getExternalStorageDirectory()
     else
       Future<Directory?>.value()

--- a/packages/cbl_flutter/lib/cbl_flutter.dart
+++ b/packages/cbl_flutter/lib/cbl_flutter.dart
@@ -29,7 +29,10 @@ class CouchbaseLiteFlutter {
 Future<InitContext> _context() async {
   final directories = await Future.wait([
     getApplicationSupportDirectory(),
-    getExternalStorageDirectory().onError<UnsupportedError>((_, __) => null),
+    if (!Platform.isIOS)
+      getExternalStorageDirectory()
+    else
+      Future<Directory?>.value()
   ]);
 
   final filesDir = directories[0]!;


### PR DESCRIPTION
`Error` (not `Exception`) should not be caught by `try/catch` or `onError`. [See more](https://api.dart.dev/stable/2.4.0/dart-core/Error-class.html)

As `getExternalStorageDirectory` method is not supported on iOS we must never call the method on iOS platform.