### PR TITLE
fix: don't require trailing path separator when copying databases

### DIFF
--- a/packages/cbl/lib/src/database/database.dart
+++ b/packages/cbl/lib/src/database/database.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+// ignore: no_leading_underscores_for_library_prefixes
 import 'package:path/path.dart' as _path;
 
 import '../document/blob.dart';

--- a/packages/cbl/lib/src/database/database.dart
+++ b/packages/cbl/lib/src/database/database.dart
@@ -3,8 +3,6 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
-// ignore: no_leading_underscores_for_library_prefixes
-import 'package:path/path.dart' as _path;
 
 import '../document/blob.dart';
 import '../document/document.dart';
@@ -235,11 +233,7 @@ abstract class Database implements ClosableResource {
     required String name,
     DatabaseConfiguration? config,
   }) =>
-      AsyncDatabase.copy(
-        from: _formatCopyFromPath(from),
-        name: name,
-        config: config,
-      );
+      AsyncDatabase.copy(from: from, name: name, config: config);
 
   /// {@template cbl.Database.copySync}
   /// Copies a canned database [from] the given path to a new database with the
@@ -253,19 +247,7 @@ abstract class Database implements ClosableResource {
     required String name,
     DatabaseConfiguration? config,
   }) =>
-      SyncDatabase.copy(
-        from: _formatCopyFromPath(from),
-        name: name,
-        config: config,
-      );
-
-  static String _formatCopyFromPath(String from) =>
-      // TODO(blaugold): remove workaround once the CBL C SDK is fixed
-      // Ensure that the path ends with a separator to signal that it is a
-      // directory.
-      // This is currently required by the native implementation.
-      // https://github.com/cbl-dart/cbl-dart/issues/444
-      _path.normalize(from) + _path.separator;
+      SyncDatabase.copy(from: from, name: name, config: config);
 
   /// Configuration of the [ConsoleLogger], [FileLogger] and a custom [Logger].
   static final Log log = LogImpl();

--- a/packages/cbl/lib/src/database/database.dart
+++ b/packages/cbl/lib/src/database/database.dart
@@ -265,7 +265,7 @@ abstract class Database implements ClosableResource {
       // directory.
       // This is currently required by the native implementation.
       // https://github.com/cbl-dart/cbl-dart/issues/444
-      Uri.parse(from).pathSegments.last.isEmpty ? from : _path.join(from, '');
+      _path.normalize(from) + _path.separator;
 
   /// Configuration of the [ConsoleLogger], [FileLogger] and a custom [Logger].
   static final Log log = LogImpl();

--- a/packages/cbl/lib/src/database/database.dart
+++ b/packages/cbl/lib/src/database/database.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as _path;
 
 import '../document/blob.dart';
 import '../document/document.dart';
@@ -233,7 +234,11 @@ abstract class Database implements ClosableResource {
     required String name,
     DatabaseConfiguration? config,
   }) =>
-      AsyncDatabase.copy(from: from, name: name, config: config);
+      AsyncDatabase.copy(
+        from: _formatCopyFromPath(from),
+        name: name,
+        config: config,
+      );
 
   /// {@template cbl.Database.copySync}
   /// Copies a canned database [from] the given path to a new database with the
@@ -247,7 +252,19 @@ abstract class Database implements ClosableResource {
     required String name,
     DatabaseConfiguration? config,
   }) =>
-      SyncDatabase.copy(from: from, name: name, config: config);
+      SyncDatabase.copy(
+        from: _formatCopyFromPath(from),
+        name: name,
+        config: config,
+      );
+
+  static String _formatCopyFromPath(String from) =>
+      // TODO(blaugold): remove workaround once the CBL C SDK is fixed
+      // Ensure that the path ends with a separator to signal that it is a
+      // directory.
+      // This is currently required by the native implementation.
+      // https://github.com/cbl-dart/cbl-dart/issues/444
+      Uri.parse(from).pathSegments.last.isEmpty ? from : _path.join(from, '');
 
   /// Configuration of the [ConsoleLogger], [FileLogger] and a custom [Logger].
   static final Log log = LogImpl();

--- a/packages/cbl/lib/src/database/ffi_database.dart
+++ b/packages/cbl/lib/src/database/ffi_database.dart
@@ -96,7 +96,6 @@ class FfiDatabase
   /// This is currently required by the native implementation.
   ///
   /// https://github.com/cbl-dart/cbl-dart/issues/444
-  ///
   // TODO(blaugold): remove workaround once the CBL C SDK is fixed
   static String _formatCopyFromPath(String from) =>
       path_lib.normalize(from) + path_lib.separator;

--- a/packages/cbl/lib/src/database/ffi_database.dart
+++ b/packages/cbl/lib/src/database/ffi_database.dart
@@ -3,6 +3,7 @@ import 'dart:ffi';
 import 'dart:io';
 
 import 'package:cbl_ffi/cbl_ffi.dart';
+import 'package:path/path.dart' as path_lib;
 
 import '../document/blob.dart';
 import '../document/document.dart';
@@ -83,11 +84,22 @@ class FfiDatabase
   }) =>
       runWithErrorTranslation(
         () => _bindings.copyDatabase(
-          from,
+          _formatCopyFromPath(from),
           name,
           config?.toCBLDatabaseConfiguration(),
         ),
       );
+
+  /// Ensures that the path ends with a separator to signal that it is a
+  /// directory.
+  ///
+  /// This is currently required by the native implementation.
+  ///
+  /// https://github.com/cbl-dart/cbl-dart/issues/444
+  ///
+  // TODO(blaugold): remove workaround once the CBL C SDK is fixed
+  static String _formatCopyFromPath(String from) =>
+      path_lib.normalize(from) + path_lib.separator;
 
   final Pointer<CBLDatabase> pointer;
 

--- a/packages/cbl/pubspec.yaml
+++ b/packages/cbl/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   collection: ^1.15.0
   ffi: ^2.0.1
   meta: ^1.3.0
+  path: ^1.8.0
   stream_channel: ^2.1.0
   synchronized: ^3.0.0
   web_socket_channel: ^2.1.0

--- a/packages/cbl_e2e_tests/lib/src/database/database_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/database/database_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:cbl/cbl.dart';
 import 'package:cbl/src/support/utils.dart';
+import 'package:path/path.dart' as path;
 
 import '../../test_binding_impl.dart';
 import '../test_binding.dart';
@@ -46,6 +47,22 @@ void main() {
 
       await copyDatabase(
         from: source.path!,
+        name: 'copy',
+        config: DatabaseConfiguration(directory: directory),
+      );
+
+      expect(await databaseExists('copy', directory: directory), isTrue);
+    });
+
+    apiTest('copy without trailing path separator in from path', () async {
+      // https://github.com/cbl-dart/cbl-dart/issues/444
+      final source = await openTestDatabase();
+      final directory = databaseDirectoryForTest();
+
+      expect(source.path, endsWith(path.separator));
+
+      await copyDatabase(
+        from: source.path!.substring(0, source.path!.length - 1),
         name: 'copy',
         config: DatabaseConfiguration(directory: directory),
       );


### PR DESCRIPTION
Fixes #444