### PR TITLE
fix: end transactions exactly once

### DIFF
--- a/packages/cbl/lib/src/replication/document_replication.dart
+++ b/packages/cbl/lib/src/replication/document_replication.dart
@@ -74,7 +74,7 @@ class ReplicatedDocumentImpl implements ReplicatedDocument {
         'ReplicatedDocument(',
         [
           id,
-          for (var flag in flags)
+          for (final flag in flags)
             if (flag == DocumentFlag.accessRemoved)
               'ACCESS-REMOVED'
             else if (flag == DocumentFlag.deleted)


### PR DESCRIPTION
This addresses an issue where after the ending of a transaction failed, the exception handler tried to end the transaction again.