### PR TITLE
fix: workaround Dart bug when destructuring record containing `Finalizable`

### DIFF
--- a/packages/cbl/lib/src/replication/ffi_replicator.dart
+++ b/packages/cbl/lib/src/replication/ffi_replicator.dart
@@ -57,8 +57,12 @@ class FfiReplicator
     // ignore: parameter_assignments
     config = ReplicatorConfiguration.from(config);
 
-    final (database, collections) = await resolveReplicatorCollections<
+    // TODO(blaugold): Use record destructuring once issue in Dart is fixed
+    // https://github.com/dart-lang/sdk/issues/54414
+    final replicatorCollections = await resolveReplicatorCollections<
         SyncDatabase, SyncCollection, FfiDatabase, FfiCollection>(config);
+    final database = replicatorCollections.$1;
+    final collections = replicatorCollections.$2;
 
     final target = config.target;
     if (target is DatabaseEndpoint) {


### PR DESCRIPTION
Dart SDK issue: https://github.com/dart-lang/sdk/issues/54414