### PR TITLE
feat!: remove `DartConsoleLogger` and stop initializing `Database.log.custom` with it

### DIFF
--- a/docs/docs/databases.mdx
+++ b/docs/docs/databases.mdx
@@ -167,36 +167,8 @@ database errors and generate more verbose messages (see `api|enum:LogLevel`)
 
 <CodeExample id={4} title="Increase level of Database Log Messages">
 
-<EmbedderTabs>
-<EmbedderTab embedder="Dart">
-
 ```dart
 Database.log.console.level = LogLevel.verbose;
 ```
-
-:::note
-
-On standalone Dart, logging is configured to directly log to stdandard output
-and does not go through Dart.
-
-:::
-
-</EmbedderTab>
-<EmbedderTab embedder="Flutter">
-
-```dart
-Database.log.custom!.level = LogLevel.verbose;
-```
-
-:::note
-
-On Flutter, logging is configured to use a custom logger that calls Dart's
-`api|dart:core|fn:print` function. Console logging is disabled. This is because
-not all Flutter platforms (e.g. Android) support console logging.
-
-:::
-
-</EmbedderTab>
-</EmbedderTabs>
 
 </CodeExample>

--- a/packages/cbl/lib/src/log.dart
+++ b/packages/cbl/lib/src/log.dart
@@ -2,10 +2,4 @@ export 'log/console_logger.dart' show ConsoleLogger;
 export 'log/file_logger.dart' show FileLogger, LogFileConfiguration;
 export 'log/log.dart' show Log;
 export 'log/logger.dart'
-    show
-        LogMessage,
-        Logger,
-        StreamLogger,
-        LogDomain,
-        LogLevel,
-        DartConsoleLogger;
+    show LogMessage, Logger, StreamLogger, LogDomain, LogLevel;

--- a/packages/cbl/lib/src/log/logger.dart
+++ b/packages/cbl/lib/src/log/logger.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ffi';
 
 import 'package:cbl_ffi/cbl_ffi.dart';
 
@@ -181,6 +182,7 @@ void _setupCallback() {
 }
 
 void _cleanUpCallback() {
+  _bindings.setCallback(nullptr);
   _callback?.close();
   _callback = null;
 }

--- a/packages/cbl/lib/src/log/logger.dart
+++ b/packages/cbl/lib/src/log/logger.dart
@@ -4,7 +4,6 @@ import 'package:cbl_ffi/cbl_ffi.dart';
 
 import '../support/async_callback.dart';
 import '../support/ffi.dart';
-import 'console_logger.dart';
 
 /// Subsystems that log information.
 ///
@@ -95,60 +94,6 @@ class StreamLogger extends Logger {
   @override
   void log(LogLevel level, LogDomain domain, String message) =>
       _controller.add(LogMessage(level, domain, message));
-}
-
-/// A [Logger] which formats logs in the same way as [ConsoleLogger] but uses
-/// Dart's [print] function.
-///
-/// {@category Logging}
-class DartConsoleLogger extends Logger {
-  /// Creates a [Logger] which formats logs in the same way as [ConsoleLogger]
-  /// but uses Dart's [print] function.
-  DartConsoleLogger([super.level]);
-
-  @override
-  void log(LogLevel level, LogDomain domain, String message) {
-    // ignore: avoid_print
-    print(_formatLogMessage(level, domain, message));
-  }
-
-  static String _formatLogMessage(
-    LogLevel level,
-    LogDomain domain,
-    String message,
-  ) =>
-      '${_logTimeStamp()}| '
-      '[${_formatDomain(domain)}] '
-      '${level.name}: $message';
-
-  static String _logTimeStamp() {
-    final now = DateTime.now();
-
-    final h = _twoDigits(now.hour);
-    final m = _twoDigits(now.minute);
-    final s = _twoDigits(now.second);
-    final microseconds = now.millisecond * 1000 + now.microsecond;
-    final us = _paddedDigits(microseconds, digits: 6);
-    return '$h:$m:$s.$us';
-  }
-
-  static String _formatDomain(LogDomain domain) {
-    switch (domain) {
-      case LogDomain.database:
-        return 'DB';
-      case LogDomain.query:
-        return 'Query';
-      case LogDomain.replicator:
-        return 'Sync';
-      case LogDomain.network:
-        return 'WS';
-    }
-  }
-
-  static String _paddedDigits(int value, {required int digits}) =>
-      value.toString().padLeft(digits, '0');
-
-  static String _twoDigits(int value) => _paddedDigits(value, digits: 2);
 }
 
 // === Impl ====================================================================

--- a/packages/cbl_dart/lib/cbl_dart.dart
+++ b/packages/cbl_dart/lib/cbl_dart.dart
@@ -48,16 +48,10 @@ class CouchbaseLiteDart {
           initContext: context,
           libraries: libraries,
         ));
-
-        _setupLogging();
       });
 }
 
 Future<InitContext> _initContext(String filesDir) async {
   await Directory(filesDir).create(recursive: true);
   return InitContext(filesDir: filesDir, tempDir: filesDir);
-}
-
-void _setupLogging() {
-  Database.log.console.level = LogLevel.warning;
 }

--- a/packages/cbl_e2e_tests/lib/src/log/logger_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/log/logger_test.dart
@@ -51,7 +51,7 @@ void main() {
       cblLogMessage(LogDomain.network, LogLevel.error, 'A');
 
       // Logs are delivered asynchronously. If the logger is removed to early
-      // it nevers sees the message.
+      // it never sees the message.
       await receivedMessage.future;
 
       Database.log.custom = null;

--- a/packages/cbl_e2e_tests/lib/src/test_binding.dart
+++ b/packages/cbl_e2e_tests/lib/src/test_binding.dart
@@ -68,8 +68,6 @@ abstract class CblE2eTestBinding {
 
   late final String largeJsonFixture;
 
-  bool get useDartConsoleLogger => false;
-
   TestFn get testFn => t.test;
 
   GroupFn get groupFn => t.group;
@@ -123,11 +121,7 @@ abstract class CblE2eTestBinding {
         )
         ..level = fileLogLevel;
 
-      if (useDartConsoleLogger) {
-        Database.log.custom = DartConsoleLogger(consoleLogLevel);
-      } else {
-        Database.log.console.level = consoleLogLevel;
-      }
+      Database.log.console.level = consoleLogLevel;
 
       largeJsonFixture = await loadLargeJsonFixture();
     });

--- a/packages/cbl_e2e_tests_flutter/integration_test/test_binding_impl.dart
+++ b/packages/cbl_e2e_tests_flutter/integration_test/test_binding_impl.dart
@@ -37,9 +37,6 @@ class FlutterCblE2eTestBinding extends CblE2eTestBinding {
       .loadString('packages/cbl_e2e_tests/src/fixtures/1000people.json');
 
   @override
-  bool get useDartConsoleLogger => true;
-
-  @override
   final testFn = (description, body) =>
       ft.testWidgets(description, (tester) async => await body());
 

--- a/packages/cbl_flutter/lib/cbl_flutter.dart
+++ b/packages/cbl_flutter/lib/cbl_flutter.dart
@@ -21,8 +21,6 @@ class CouchbaseLiteFlutter {
           libraries: CblFlutterPlatform.instance.libraries(),
           initContext: await _context(),
         ));
-
-        _setupLogging();
       });
 }
 
@@ -47,13 +45,4 @@ Future<InitContext> _context() async {
     filesDir: filesDir.path,
     tempDir: clbTempDir.path,
   );
-}
-
-void _setupLogging() {
-  Database.log
-    // stdout and stderr is not visible to Flutter developers, usually. That is
-    // why the console logger is disabled and a custom logger which logs to
-    // Dart's `print` functions is installed.
-    ..console.level = LogLevel.none
-    ..custom = DartConsoleLogger(LogLevel.warning);
 }


### PR DESCRIPTION
Since the builtin console logger now logs to logcat on Android the `DartConsoleLogger` is no longer necessary to support console logs on all platforms.