### PR TITLE
test: upgrade to `compileSdk = 34` to allow running integration tests again

### DIFF
--- a/packages/cbl_e2e_tests_flutter/android/app/build.gradle
+++ b/packages/cbl_e2e_tests_flutter/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk = 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/cbl_flutter_prebuilt_e2e_tests/android/app/build.gradle
+++ b/packages/cbl_flutter_prebuilt_e2e_tests/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk = 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Fixes #604