### PR TITLE
fix: using hard coded bash path

### DIFF
--- a/packages/cbl_flutter_ce/windows/CMakeLists.txt
+++ b/packages/cbl_flutter_ce/windows/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 
 execute_process(
-  COMMAND "C:\\Program Files\\Git\\bin\\bash.exe" "${PROJECT_SOURCE_DIR}/../tool/install_libraries.sh" windows-x86_64
+  COMMAND "bash.exe" "${PROJECT_SOURCE_DIR}/../tool/install_libraries.sh" windows-x86_64
   RESULT_VARIABLE INSTALL_LIBRARIES_RESULT
   OUTPUT_VARIABLE INSTALL_LIBRARIES_OUTPUT
   ERROR_VARIABLE INSTALL_LIBRARIES_ERROR

--- a/packages/cbl_flutter_ee/windows/CMakeLists.txt
+++ b/packages/cbl_flutter_ee/windows/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 
 execute_process(
-  COMMAND "C:\\Program Files\\Git\\bin\\bash.exe" "${PROJECT_SOURCE_DIR}/../tool/install_libraries.sh" windows-x86_64
+  COMMAND "bash.exe" "${PROJECT_SOURCE_DIR}/../tool/install_libraries.sh" windows-x86_64
   RESULT_VARIABLE INSTALL_LIBRARIES_RESULT
   OUTPUT_VARIABLE INSTALL_LIBRARIES_OUTPUT
   ERROR_VARIABLE INSTALL_LIBRARIES_ERROR

--- a/packages/cbl_flutter_prebuilt/template_package/windows/CMakeLists.txt__template__
+++ b/packages/cbl_flutter_prebuilt/template_package/windows/CMakeLists.txt__template__
@@ -18,7 +18,7 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 
 execute_process(
-  COMMAND "C:\\Program Files\\Git\\bin\\bash.exe" "${PROJECT_SOURCE_DIR}/../tool/install_libraries.sh" windows-x86_64
+  COMMAND "bash.exe" "${PROJECT_SOURCE_DIR}/../tool/install_libraries.sh" windows-x86_64
   RESULT_VARIABLE INSTALL_LIBRARIES_RESULT
   OUTPUT_VARIABLE INSTALL_LIBRARIES_OUTPUT
   ERROR_VARIABLE INSTALL_LIBRARIES_ERROR


### PR DESCRIPTION
Sometimes (like in my case) people don't install git in `C:` or even don't use git as a `bash.exe` provider. but bash is definitely in the path so instead of hardcoding the absolute path, only use the `bash.exe`