### PR TITLE
refactor: disable comments and Dart enums for FFI bindings

### DIFF
--- a/packages/cbl/cblite_ffigen.yaml
+++ b/packages/cbl/cblite_ffigen.yaml
@@ -38,6 +38,10 @@ structs:
       _private1: private1
       _private2: private2
       _private3: private3
+enums:
+  as-int:
+    include:
+      - '.*'
 compiler-opts:
   - '-I../../native/vendor/cblite/include'
   # CBL uses a macro to define enums which is called CBL_ENUM.

--- a/packages/cbl/cblite_ffigen.yaml
+++ b/packages/cbl/cblite_ffigen.yaml
@@ -5,6 +5,7 @@ output:
   symbol-file:
     output: package:cbl/src/bindings/cblite_symbols.yaml
     import-path: package:cbl/src/bindings/cblite.dart
+comments: false
 preamble: |
   // ignore_for_file: unused_field
 headers:

--- a/packages/cbl/cblitedart_ffigen.yaml
+++ b/packages/cbl/cblitedart_ffigen.yaml
@@ -26,6 +26,10 @@ functions:
       - CBLDart_FLSliceResult_ReleaseByBuf
       - CBLDart_KnownSharedKeys_Delete
       - CBLDart_PredictiveModel_Delete
+enums:
+  as-int:
+    include:
+      - '.*'
 compiler-opts:
   - '-I../../native/couchbase-lite-dart/include'
   - '-I../../native/vendor/cblite/include'

--- a/packages/cbl/cblitedart_ffigen.yaml
+++ b/packages/cbl/cblitedart_ffigen.yaml
@@ -5,6 +5,7 @@ output:
 import:
   symbol-files:
     - package:cbl/src/bindings/cblite_symbols.yaml
+comments: false
 headers:
   entry-points:
     - ../../native/couchbase-lite-dart/include/CBL+Dart.h

--- a/packages/cbl/lib/src/bindings/base.dart
+++ b/packages/cbl/lib/src/bindings/base.dart
@@ -42,6 +42,32 @@ extension OptionIterable<T extends Option> on Iterable<T> {
 
 // === Init ====================================================================
 
+enum CBLDartInitializeResult {
+  success(
+      cblitedart.CBLDartInitializeResult.CBLDartInitializeResult_kCBLInitError),
+  incompatibleDartVM(cblitedart
+      .CBLDartInitializeResult.CBLDartInitializeResult_kIncompatibleDartVM),
+  cblInitError(
+      cblitedart.CBLDartInitializeResult.CBLDartInitializeResult_kCBLInitError);
+
+  const CBLDartInitializeResult(this.value);
+
+  static CBLDartInitializeResult fromValue(int value) => switch (value) {
+        cblitedart.CBLDartInitializeResult.CBLDartInitializeResult_kSuccess =>
+          success,
+        cblitedart.CBLDartInitializeResult
+              .CBLDartInitializeResult_kIncompatibleDartVM =>
+          incompatibleDartVM,
+        cblitedart
+              .CBLDartInitializeResult.CBLDartInitializeResult_kCBLInitError =>
+          cblInitError,
+        _ => throw ArgumentError(
+            'Unknown value for CBLDartInitializeResult: $value'),
+      };
+
+  final int value;
+}
+
 final class CBLInitContext {
   CBLInitContext({required this.filesDir, required this.tempDir});
 
@@ -244,7 +270,7 @@ extension IntErrorCodeExt on int {
         CBLErrorDomain.couchbaseLite => CBLErrorCode.fromValue(this),
         CBLErrorDomain.posix => this,
         CBLErrorDomain.sqLite => this,
-        CBLErrorDomain.fleece => cblite.FLError.fromValue(this),
+        CBLErrorDomain.fleece => FLError.fromValue(this),
         CBLErrorDomain.network => CBLNetworkErrorCode.fromValue(this),
         CBLErrorDomain.webSocket => this
       };

--- a/packages/cbl/lib/src/bindings/cblite.dart
+++ b/packages/cbl/lib/src/bindings/cblite.dart
@@ -21,8 +21,6 @@ class cblite {
           lookup)
       : _lookup = lookup;
 
-  /// Returns a message describing an error. @note You are responsible for
-  /// releasing the result by calling \ref FLSliceResult_Release.
   FLSliceResult CBLError_Message(
     ffi.Pointer<CBLError> outError,
   ) {
@@ -36,7 +34,6 @@ class cblite {
   late final _CBLError_Message =
       _CBLError_MessagePtr.asFunction<DartCBLError_Message>();
 
-  /// Returns the current time, in milliseconds since 1/1/1970.
   int CBL_Now() {
     return _CBL_Now();
   }
@@ -45,9 +42,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeCBL_Now>>('CBL_Now');
   late final _CBL_Now = _CBL_NowPtr.asFunction<DartCBL_Now>();
 
-  /// Increments an object's reference-count. Usually you'll call one of the
-  /// type-safe synonyms specific to the object type, like \ref
-  /// CBLDatabase_Retain`
   ffi.Pointer<CBLRefCounted> CBL_Retain(
     ffi.Pointer<CBLRefCounted> arg0,
   ) {
@@ -60,9 +54,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeCBL_Retain>>('CBL_Retain');
   late final _CBL_Retain = _CBL_RetainPtr.asFunction<DartCBL_Retain>();
 
-  /// Decrements an object's reference-count, freeing the object if the count
-  /// hits zero. Usually you'll call one of the type-safe synonyms specific to
-  /// the object type, like \ref CBLDatabase_Release.
   void CBL_Release(
     ffi.Pointer<CBLRefCounted> arg0,
   ) {
@@ -75,8 +66,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeCBL_Release>>('CBL_Release');
   late final _CBL_Release = _CBL_ReleasePtr.asFunction<DartCBL_Release>();
 
-  /// Returns the total number of Couchbase Lite objects. Useful for leak
-  /// checking.
   int CBL_InstanceCount() {
     return _CBL_InstanceCount();
   }
@@ -86,8 +75,6 @@ class cblite {
   late final _CBL_InstanceCount =
       _CBL_InstanceCountPtr.asFunction<DartCBL_InstanceCount>();
 
-  /// Logs the class and address of each Couchbase Lite object. Useful for leak
-  /// checking. @note May only be functional in debug builds of Couchbase Lite.
   void CBL_DumpInstances() {
     return _CBL_DumpInstances();
   }
@@ -97,8 +84,6 @@ class cblite {
   late final _CBL_DumpInstances =
       _CBL_DumpInstancesPtr.asFunction<DartCBL_DumpInstances>();
 
-  /// Removes a listener callback, given the token that was returned when it was
-  /// added.
   void CBLListener_Remove(
     ffi.Pointer<CBLListenerToken> arg0,
   ) {
@@ -113,33 +98,26 @@ class cblite {
   late final _CBLListener_Remove =
       _CBLListener_RemovePtr.asFunction<DartCBLListener_Remove>();
 
-  /// < `"blob"`
   late final ffi.Pointer<FLSlice> _kCBLBlobType =
       _lookup<FLSlice>('kCBLBlobType');
 
   FLSlice get kCBLBlobType => _kCBLBlobType.ref;
 
-  /// < `"digest"`
   late final ffi.Pointer<FLSlice> _kCBLBlobDigestProperty =
       _lookup<FLSlice>('kCBLBlobDigestProperty');
 
   FLSlice get kCBLBlobDigestProperty => _kCBLBlobDigestProperty.ref;
 
-  /// < `"length"`
   late final ffi.Pointer<FLSlice> _kCBLBlobLengthProperty =
       _lookup<FLSlice>('kCBLBlobLengthProperty');
 
   FLSlice get kCBLBlobLengthProperty => _kCBLBlobLengthProperty.ref;
 
-  /// < `"content_type"`
   late final ffi.Pointer<FLSlice> _kCBLBlobContentTypeProperty =
       _lookup<FLSlice>('kCBLBlobContentTypeProperty');
 
   FLSlice get kCBLBlobContentTypeProperty => _kCBLBlobContentTypeProperty.ref;
 
-  /// Returns true if a dictionary in a document is a blob reference. If so, you
-  /// can call \ref FLDict_GetBlob to access it. @note This function tests
-  /// whether the dictionary has a `@type` property, whose value is `"blob"`.
   bool FLDict_IsBlob(
     FLDict arg0,
   ) {
@@ -152,9 +130,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLDict_IsBlob>>('FLDict_IsBlob');
   late final _FLDict_IsBlob = _FLDict_IsBlobPtr.asFunction<DartFLDict_IsBlob>();
 
-  /// Returns a CBLBlob object corresponding to a blob dictionary in a document.
-  /// @param blobDict A dictionary in a document. @return A CBLBlob instance for
-  /// this blob, or NULL if the dictionary is not a blob.
   ffi.Pointer<CBLBlob> FLDict_GetBlob(
     FLDict blobDict,
   ) {
@@ -168,8 +143,6 @@ class cblite {
   late final _FLDict_GetBlob =
       _FLDict_GetBlobPtr.asFunction<DartFLDict_GetBlob>();
 
-  /// Returns the length in bytes of a blob's content (from its `length`
-  /// property).
   int CBLBlob_Length(
     ffi.Pointer<CBLBlob> arg0,
   ) {
@@ -183,7 +156,6 @@ class cblite {
   late final _CBLBlob_Length =
       _CBLBlob_LengthPtr.asFunction<DartCBLBlob_Length>();
 
-  /// Returns a blob's MIME type, if its metadata has a `content_type` property.
   FLString CBLBlob_ContentType(
     ffi.Pointer<CBLBlob> arg0,
   ) {
@@ -198,8 +170,6 @@ class cblite {
   late final _CBLBlob_ContentType =
       _CBLBlob_ContentTypePtr.asFunction<DartCBLBlob_ContentType>();
 
-  /// Returns the cryptographic digest of a blob's content (from its `digest`
-  /// property).
   FLString CBLBlob_Digest(
     ffi.Pointer<CBLBlob> arg0,
   ) {
@@ -213,9 +183,6 @@ class cblite {
   late final _CBLBlob_Digest =
       _CBLBlob_DigestPtr.asFunction<DartCBLBlob_Digest>();
 
-  /// Returns a blob's metadata. This includes the `digest`, `length`,
-  /// `content_type`, and `@type` properties, as well as any custom ones that
-  /// may have been added.
   FLDict CBLBlob_Properties(
     ffi.Pointer<CBLBlob> arg0,
   ) {
@@ -230,7 +197,6 @@ class cblite {
   late final _CBLBlob_Properties =
       _CBLBlob_PropertiesPtr.asFunction<DartCBLBlob_Properties>();
 
-  /// Returns a blob's metadata as JSON.
   FLStringResult CBLBlob_CreateJSON(
     ffi.Pointer<CBLBlob> blob,
   ) {
@@ -245,9 +211,6 @@ class cblite {
   late final _CBLBlob_CreateJSON =
       _CBLBlob_CreateJSONPtr.asFunction<DartCBLBlob_CreateJSON>();
 
-  /// Reads the blob's content into memory and returns them. @note You are
-  /// responsible for releasing the result by calling \ref
-  /// FLSliceResult_Release.
   FLSliceResult CBLBlob_Content(
     ffi.Pointer<CBLBlob> blob,
     ffi.Pointer<CBLError> outError,
@@ -263,7 +226,6 @@ class cblite {
   late final _CBLBlob_Content =
       _CBLBlob_ContentPtr.asFunction<DartCBLBlob_Content>();
 
-  /// Opens a stream for reading a blob's content.
   ffi.Pointer<CBLBlobReadStream> CBLBlob_OpenContentStream(
     ffi.Pointer<CBLBlob> blob,
     ffi.Pointer<CBLError> arg1,
@@ -280,11 +242,6 @@ class cblite {
   late final _CBLBlob_OpenContentStream =
       _CBLBlob_OpenContentStreamPtr.asFunction<DartCBLBlob_OpenContentStream>();
 
-  /// Reads data from a blob. @param stream The stream to read from. @param dst
-  /// The address to copy the read data to. @param maxLength The maximum number
-  /// of bytes to read. @param outError On failure, an error will be stored here
-  /// if non-NULL. @return The actual number of bytes read; 0 if at EOF, -1 on
-  /// error.
   int CBLBlobReader_Read(
     ffi.Pointer<CBLBlobReadStream> stream,
     ffi.Pointer<ffi.Void> dst,
@@ -305,11 +262,6 @@ class cblite {
   late final _CBLBlobReader_Read =
       _CBLBlobReader_ReadPtr.asFunction<DartCBLBlobReader_Read>();
 
-  /// Sets the position of a CBLBlobReadStream. @param stream The stream to
-  /// reposition. @param offset The byte offset in the stream (relative to the
-  /// `mode`). @param base The base position from which the offset is
-  /// calculated. @param outError On failure, an error will be stored here if
-  /// non-NULL. @return The new absolute position, or -1 on failure.
   int CBLBlobReader_Seek(
     ffi.Pointer<CBLBlobReadStream> stream,
     int offset,
@@ -330,7 +282,6 @@ class cblite {
   late final _CBLBlobReader_Seek =
       _CBLBlobReader_SeekPtr.asFunction<DartCBLBlobReader_Seek>();
 
-  /// Returns the current position of a CBLBlobReadStream.
   int CBLBlobReader_Position(
     ffi.Pointer<CBLBlobReadStream> stream,
   ) {
@@ -345,7 +296,6 @@ class cblite {
   late final _CBLBlobReader_Position =
       _CBLBlobReader_PositionPtr.asFunction<DartCBLBlobReader_Position>();
 
-  /// Closes a CBLBlobReadStream.
   void CBLBlobReader_Close(
     ffi.Pointer<CBLBlobReadStream> arg0,
   ) {
@@ -360,7 +310,6 @@ class cblite {
   late final _CBLBlobReader_Close =
       _CBLBlobReader_ClosePtr.asFunction<DartCBLBlobReader_Close>();
 
-  /// Compares whether the two given blobs are equal based on their content.
   bool CBLBlob_Equals(
     ffi.Pointer<CBLBlob> blob,
     ffi.Pointer<CBLBlob> anotherBlob,
@@ -376,11 +325,6 @@ class cblite {
   late final _CBLBlob_Equals =
       _CBLBlob_EqualsPtr.asFunction<DartCBLBlob_Equals>();
 
-  /// Creates a new blob given its contents as a single block of data. @note You
-  /// are responsible for releasing the \ref CBLBlob, but not until after its
-  /// document has been saved. @param contentType The MIME type (optional).
-  /// @param contents The data's address and length. @return A new CBLBlob
-  /// instance.
   ffi.Pointer<CBLBlob> CBLBlob_CreateWithData(
     FLString contentType,
     FLSlice contents,
@@ -397,11 +341,6 @@ class cblite {
   late final _CBLBlob_CreateWithData =
       _CBLBlob_CreateWithDataPtr.asFunction<DartCBLBlob_CreateWithData>();
 
-  /// Opens a stream for writing a new blob. You should next call \ref
-  /// CBLBlobWriter_Write one or more times to write the data, then \ref
-  /// CBLBlob_CreateWithStream to create the blob.
-  ///
-  /// If for some reason you need to abort, just call \ref CBLBlobWriter_Close.
   ffi.Pointer<CBLBlobWriteStream> CBLBlobWriter_Create(
     ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLError> arg1,
@@ -418,8 +357,6 @@ class cblite {
   late final _CBLBlobWriter_Create =
       _CBLBlobWriter_CreatePtr.asFunction<DartCBLBlobWriter_Create>();
 
-  /// Closes a blob-writing stream, if you need to give up without creating a
-  /// \ref CBLBlob.
   void CBLBlobWriter_Close(
     ffi.Pointer<CBLBlobWriteStream> arg0,
   ) {
@@ -434,10 +371,6 @@ class cblite {
   late final _CBLBlobWriter_Close =
       _CBLBlobWriter_ClosePtr.asFunction<DartCBLBlobWriter_Close>();
 
-  /// Writes data to a new blob. @param writer The stream to write to. @param
-  /// data The address of the data to write. @param length The length of the
-  /// data to write. @param outError On failure, error info will be written
-  /// here. @return True on success, false on failure.
   bool CBLBlobWriter_Write(
     ffi.Pointer<CBLBlobWriteStream> writer,
     ffi.Pointer<ffi.Void> data,
@@ -458,13 +391,6 @@ class cblite {
   late final _CBLBlobWriter_Write =
       _CBLBlobWriter_WritePtr.asFunction<DartCBLBlobWriter_Write>();
 
-  /// Creates a new blob after its data has been written to a \ref
-  /// CBLBlobWriteStream. You should then add the blob to a mutable document as
-  /// a property -- see \ref FLSlot_SetBlob. @note You are responsible for
-  /// releasing the CBLBlob reference. @note Do not free the stream; the blob
-  /// will do that. @param contentType The MIME type (optional). @param writer
-  /// The blob-writing stream the data was written to. @return A new CBLBlob
-  /// instance.
   ffi.Pointer<CBLBlob> CBLBlob_CreateWithStream(
     FLString contentType,
     ffi.Pointer<CBLBlobWriteStream> writer,
@@ -496,22 +422,6 @@ class cblite {
   late final _FLSlot_SetBlob =
       _FLSlot_SetBlobPtr.asFunction<DartFLSlot_SetBlob>();
 
-  /// Get a \ref CBLBlob object from the database using the \ref CBLBlob
-  /// properties.
-  ///
-  /// The \ref CBLBlob properties is a blob's metadata containing two required
-  /// fields which are a special marker property `"@type":"blob"`, and property
-  /// `digest` whose value is a hex SHA-1 digest of the blob's data. The other
-  /// optional properties are `length` and `content_type`. To obtain the \ref
-  /// CBLBlob properties from a \ref CBLBlob, call \ref CBLBlob_Properties
-  /// function.
-  ///
-  /// @note You must release the \ref CBLBlob when you're finished with it.
-  /// @param db The database. @param properties The properties for getting the
-  /// \ref CBLBlob object. @param outError On failure, error info will be
-  /// written here if specified. A nonexistent blob is not considered a failure;
-  /// in that event the error code will be zero. @return A \ref CBLBlob
-  /// instance, or NULL if the doc doesn't exist or an error occurred.
   ffi.Pointer<CBLBlob> CBLDatabase_GetBlob(
     ffi.Pointer<CBLDatabase> db,
     FLDict properties,
@@ -530,19 +440,6 @@ class cblite {
   late final _CBLDatabase_GetBlob =
       _CBLDatabase_GetBlobPtr.asFunction<DartCBLDatabase_GetBlob>();
 
-  /// Save a new \ref CBLBlob object into the database without associating it
-  /// with any documents. The properties of the saved \ref CBLBlob object will
-  /// include information necessary for referencing the \ref CBLBlob object in
-  /// the properties of the document to be saved into the database.
-  ///
-  /// Normally you do not need to use this function unless you are in the
-  /// situation (e.g. developing javascript binding) that you cannot retain the
-  /// \ref CBLBlob object until the document containing the \ref CBLBlob object
-  /// is successfully saved into the database. \note The saved \ref CBLBlob
-  /// objects that are not associated with any documents will be removed from
-  /// the database when compacting the database. @param db The database. @param
-  /// blob The The CBLBlob to save. @param outError On failure, error info will
-  /// be written here.
   bool CBLDatabase_SaveBlob(
     ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLBlob> blob,
@@ -561,22 +458,11 @@ class cblite {
   late final _CBLDatabase_SaveBlob =
       _CBLDatabase_SaveBlobPtr.asFunction<DartCBLDatabase_SaveBlob>();
 
-  /// < `"@type"`
   late final ffi.Pointer<FLSlice> _kCBLTypeProperty =
       _lookup<FLSlice>('kCBLTypeProperty');
 
   FLSlice get kCBLTypeProperty => _kCBLTypeProperty.ref;
 
-  /// Reads a document from the default collection in an immutable form. Each
-  /// call to this function creates a new object (which must later be released.)
-  /// @note If you are reading the document in order to make changes to it, call
-  /// \ref CBLDatabase_GetMutableDocument instead. @warning <b>Deprecated :</b>
-  /// Use CBLCollection_GetDocument on the default collection instead. @param
-  /// database The database. @param docID The ID of the document. @param
-  /// outError On failure, the error will be written here. (A nonexistent
-  /// document is not considered a failure; in that event the error code will be
-  /// zero.) @return A new \ref CBLDocument instance, or NULL if the doc doesn't
-  /// exist or an error occurred.
   ffi.Pointer<CBLDocument> CBLDatabase_GetDocument(
     ffi.Pointer<CBLDatabase> database,
     FLString docID,
@@ -595,15 +481,6 @@ class cblite {
   late final _CBLDatabase_GetDocument =
       _CBLDatabase_GetDocumentPtr.asFunction<DartCBLDatabase_GetDocument>();
 
-  /// Saves a (mutable) document to the default collection. @warning If a newer
-  /// revision has been saved since \p doc was loaded, it will be overwritten by
-  /// this one. This can lead to data loss! To avoid this, call \ref
-  /// CBLDatabase_SaveDocumentWithConcurrencyControl or \ref
-  /// CBLDatabase_SaveDocumentWithConflictHandler instead. @warning
-  /// <b>Deprecated :</b> Use CBLCollection_SaveDocument on the default
-  /// collection instead. @param db The database. @param doc The mutable
-  /// document to save. @param outError On failure, the error will be written
-  /// here. @return True on success, false on failure.
   bool CBLDatabase_SaveDocument(
     ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLDocument> doc,
@@ -622,17 +499,6 @@ class cblite {
   late final _CBLDatabase_SaveDocument =
       _CBLDatabase_SaveDocumentPtr.asFunction<DartCBLDatabase_SaveDocument>();
 
-  /// Saves a (mutable) document to the default collection. If a conflicting
-  /// revision has been saved since \p doc was loaded, the \p concurrency
-  /// parameter specifies whether the save should fail, or the conflicting
-  /// revision should be overwritten with the revision being saved. If you need
-  /// finer-grained control, call \ref
-  /// CBLDatabase_SaveDocumentWithConflictHandler instead. @warning
-  /// <b>Deprecated :</b> Use CBLCollection_SaveDocumentWithConcurrencyControl
-  /// on the default collection instead. @param db The database. @param doc The
-  /// mutable document to save. @param concurrency Conflict-handling strategy
-  /// (fail or overwrite). @param outError On failure, the error will be written
-  /// here. @return True on success, false on failure.
   bool CBLDatabase_SaveDocumentWithConcurrencyControl(
     ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLDocument> doc,
@@ -655,15 +521,6 @@ class cblite {
       _CBLDatabase_SaveDocumentWithConcurrencyControlPtr.asFunction<
           DartCBLDatabase_SaveDocumentWithConcurrencyControl>();
 
-  /// Saves a (mutable) document to the default collection, allowing for custom
-  /// conflict handling in the event that the document has been updated since \p
-  /// doc was loaded. @warning <b>Deprecated :</b> Use
-  /// CBLCollection_SaveDocumentWithConflictHandler on the default collection
-  /// instead. @param db The database. @param doc The mutable document to save.
-  /// @param conflictHandler The callback to be invoked if there is a conflict.
-  /// @param context An arbitrary value to be passed to the \p conflictHandler.
-  /// @param outError On failure, the error will be written here. @return True
-  /// on success, false on failure.
   bool CBLDatabase_SaveDocumentWithConflictHandler(
     ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLDocument> doc,
@@ -688,12 +545,6 @@ class cblite {
       _CBLDatabase_SaveDocumentWithConflictHandlerPtr.asFunction<
           DartCBLDatabase_SaveDocumentWithConflictHandler>();
 
-  /// Deletes a document from the default collection. Deletions are replicated.
-  /// @warning You are still responsible for releasing the CBLDocument. @warning
-  /// <b>Deprecated :</b> Use CBLCollection_DeleteDocument on the default
-  /// collection instead. @param db The database. @param document The document
-  /// to delete. @param outError On failure, the error will be written here.
-  /// @return True if the document was deleted, false if an error occurred.
   bool CBLDatabase_DeleteDocument(
     ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLDocument> document,
@@ -712,13 +563,6 @@ class cblite {
   late final _CBLDatabase_DeleteDocument = _CBLDatabase_DeleteDocumentPtr
       .asFunction<DartCBLDatabase_DeleteDocument>();
 
-  /// Deletes a document from the default collection. Deletions are replicated.
-  /// @warning You are still responsible for releasing the CBLDocument. @warning
-  /// <b>Deprecated :</b> Use CBLCollection_DeleteDocumentWithConcurrencyControl
-  /// on the default collection instead. @param db The database. @param document
-  /// The document to delete. @param concurrency Conflict-handling strategy.
-  /// @param outError On failure, the error will be written here. @return True
-  /// if the document was deleted, false if an error occurred.
   bool CBLDatabase_DeleteDocumentWithConcurrencyControl(
     ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLDocument> document,
@@ -741,16 +585,6 @@ class cblite {
       _CBLDatabase_DeleteDocumentWithConcurrencyControlPtr.asFunction<
           DartCBLDatabase_DeleteDocumentWithConcurrencyControl>();
 
-  /// Purges a document from the default collection. This removes all traces of
-  /// the document. Purges are _not_ replicated. If the document is changed on a
-  /// server, it will be re-created when pulled. @warning You are still
-  /// responsible for releasing the \ref CBLDocument reference. @warning
-  /// <b>Deprecated :</b> Use CBLCollection_PurgeDocument on the default
-  /// collection instead. @note If you don't have the document in memory
-  /// already, \ref CBLDatabase_PurgeDocumentByID is a simpler shortcut. @param
-  /// db The database. @param document The document to purge. @param outError On
-  /// failure, the error will be written here. @return True if the document was
-  /// purged, false if it doesn't exist or the purge failed.
   bool CBLDatabase_PurgeDocument(
     ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLDocument> document,
@@ -769,13 +603,6 @@ class cblite {
   late final _CBLDatabase_PurgeDocument =
       _CBLDatabase_PurgeDocumentPtr.asFunction<DartCBLDatabase_PurgeDocument>();
 
-  /// Purges a document by its ID from the default collection. @note If no
-  /// document with that ID exists, this function will return false but the
-  /// error code will be zero. @warning <b>Deprecated :</b> Use
-  /// CBLCollection_PurgeDocumentByID on the default collection instead. @param
-  /// database The database. @param docID The document ID to purge. @param
-  /// outError On failure, the error will be written here. @return True if the
-  /// document was purged, false if it doesn't exist or the purge failed.
   bool CBLDatabase_PurgeDocumentByID(
     ffi.Pointer<CBLDatabase> database,
     FLString docID,
@@ -794,16 +621,6 @@ class cblite {
   late final _CBLDatabase_PurgeDocumentByID = _CBLDatabase_PurgeDocumentByIDPtr
       .asFunction<DartCBLDatabase_PurgeDocumentByID>();
 
-  /// Reads a document from the default collection in mutable form that can be
-  /// updated and saved. (This function is otherwise identical to \ref
-  /// CBLDatabase_GetDocument.) @note You must release the document when you're
-  /// done with it. @warning <b>Deprecated :</b> Use
-  /// CBLCollection_GetMutableDocument on the default collection instead. @param
-  /// database The database. @param docID The ID of the document. @param
-  /// outError On failure, the error will be written here. (A nonexistent
-  /// document is not considered a failure; in that event the error code will be
-  /// zero.) @return A new \ref CBLDocument instance, or NULL if the doc doesn't
-  /// exist or an error occurred.
   ffi.Pointer<CBLDocument> CBLDatabase_GetMutableDocument(
     ffi.Pointer<CBLDatabase> database,
     FLString docID,
@@ -823,9 +640,6 @@ class cblite {
       _CBLDatabase_GetMutableDocumentPtr.asFunction<
           DartCBLDatabase_GetMutableDocument>();
 
-  /// Creates a new, empty document in memory, with a randomly-generated unique
-  /// ID. It will not be added to a database until saved. @return The new
-  /// mutable document instance.
   ffi.Pointer<CBLDocument> CBLDocument_Create() {
     return _CBLDocument_Create();
   }
@@ -836,13 +650,6 @@ class cblite {
   late final _CBLDocument_Create =
       _CBLDocument_CreatePtr.asFunction<DartCBLDocument_Create>();
 
-  /// Creates a new, empty document in memory, with the given ID. It will not be
-  /// added to a database until saved. @note If the given ID conflicts with a
-  /// document already in the database, that will not be apparent until this
-  /// document is saved. At that time, the result depends on the conflict
-  /// handling mode used when saving; see the save functions for details. @param
-  /// docID The ID of the new document, or NULL to assign a new unique ID.
-  /// @return The new mutable document instance.
   ffi.Pointer<CBLDocument> CBLDocument_CreateWithID(
     FLString docID,
   ) {
@@ -857,12 +664,6 @@ class cblite {
   late final _CBLDocument_CreateWithID =
       _CBLDocument_CreateWithIDPtr.asFunction<DartCBLDocument_CreateWithID>();
 
-  /// Creates a new mutable CBLDocument instance that refers to the same
-  /// document as the original. If the original document has unsaved changes,
-  /// the new one will also start out with the same changes; but mutating one
-  /// document thereafter will not affect the other. @note You must release the
-  /// new reference when you're done with it. Similarly, the original document
-  /// still exists and must also be released when you're done with it.
   ffi.Pointer<CBLDocument> CBLDocument_MutableCopy(
     ffi.Pointer<CBLDocument> original,
   ) {
@@ -877,7 +678,6 @@ class cblite {
   late final _CBLDocument_MutableCopy =
       _CBLDocument_MutableCopyPtr.asFunction<DartCBLDocument_MutableCopy>();
 
-  /// Returns a document's ID.
   FLString CBLDocument_ID(
     ffi.Pointer<CBLDocument> arg0,
   ) {
@@ -891,9 +691,6 @@ class cblite {
   late final _CBLDocument_ID =
       _CBLDocument_IDPtr.asFunction<DartCBLDocument_ID>();
 
-  /// Returns a document's revision ID, which is a short opaque string that's
-  /// guaranteed to be unique to every change made to the document. If the
-  /// document doesn't exist yet, this function returns NULL.
   FLString CBLDocument_RevisionID(
     ffi.Pointer<CBLDocument> arg0,
   ) {
@@ -908,11 +705,6 @@ class cblite {
   late final _CBLDocument_RevisionID =
       _CBLDocument_RevisionIDPtr.asFunction<DartCBLDocument_RevisionID>();
 
-  /// Returns a document's current sequence in the local database. This number
-  /// increases every time the document is saved, and a more recently saved
-  /// document will have a greater sequence number than one saved earlier, so
-  /// sequences may be used as an abstract 'clock' to tell relative modification
-  /// times.
   int CBLDocument_Sequence(
     ffi.Pointer<CBLDocument> arg0,
   ) {
@@ -927,8 +719,6 @@ class cblite {
   late final _CBLDocument_Sequence =
       _CBLDocument_SequencePtr.asFunction<DartCBLDocument_Sequence>();
 
-  /// Returns a document's collection or NULL for the new document that hasn't
-  /// been saved.
   ffi.Pointer<CBLCollection> CBLDocument_Collection(
     ffi.Pointer<CBLDocument> arg0,
   ) {
@@ -943,16 +733,6 @@ class cblite {
   late final _CBLDocument_Collection =
       _CBLDocument_CollectionPtr.asFunction<DartCBLDocument_Collection>();
 
-  /// Returns a document's properties as a dictionary. @note The dictionary
-  /// object is owned by the document; you do not need to release it. @warning
-  /// When the document is released, this reference to the properties becomes
-  /// invalid. If you need to use any properties after releasing the document,
-  /// you must retain them by calling \ref FLValue*Retain (and of course later
-  /// release them.) @warning This dictionary \_reference* is immutable, but if
-  /// the document is mutable the underlying dictionary itself is mutable and
-  /// could be modified through a mutable reference obtained via \ref
-  /// CBLDocument_MutableProperties. If you need to preserve the properties,
-  /// call \ref FLDict_MutableCopy to make a deep copy.
   FLDict CBLDocument_Properties(
     ffi.Pointer<CBLDocument> arg0,
   ) {
@@ -967,18 +747,6 @@ class cblite {
   late final _CBLDocument_Properties =
       _CBLDocument_PropertiesPtr.asFunction<DartCBLDocument_Properties>();
 
-  /// Returns a mutable document's properties as a mutable dictionary. You may
-  /// modify this dictionary and then call \ref CBLDatabase_SaveDocument to
-  /// persist the changes. @note The dictionary object is owned by the document;
-  /// you do not need to release it. @note Every call to this function returns
-  /// the same mutable collection. This is the same collection returned by \ref
-  /// CBLDocument_Properties. @note When accessing nested collections inside the
-  /// properties as a mutable collection for modification, use \ref
-  /// FLMutableDict_GetMutableDict or \ref FLMutableDict_GetMutableArray.
-  /// @warning When the document is released, this reference to the properties
-  /// becomes invalid. If you need to use any properties after releasing the
-  /// document, you must retain them by calling \ref FLValue_Retain (and of
-  /// course later release them.)
   FLMutableDict CBLDocument_MutableProperties(
     ffi.Pointer<CBLDocument> arg0,
   ) {
@@ -993,10 +761,6 @@ class cblite {
   late final _CBLDocument_MutableProperties = _CBLDocument_MutablePropertiesPtr
       .asFunction<DartCBLDocument_MutableProperties>();
 
-  /// Sets a mutable document's properties. Call \ref CBLDatabase_SaveDocument
-  /// to persist the changes. @note The dictionary object will be retained by
-  /// the document. You are responsible for releasing any retained reference(s)
-  /// you have to it.
   void CBLDocument_SetProperties(
     ffi.Pointer<CBLDocument> arg0,
     FLMutableDict properties,
@@ -1013,8 +777,6 @@ class cblite {
   late final _CBLDocument_SetProperties =
       _CBLDocument_SetPropertiesPtr.asFunction<DartCBLDocument_SetProperties>();
 
-  /// Returns a document's properties as JSON. @note You are responsible for
-  /// releasing the result by calling \ref FLSliceResult_Release.
   FLSliceResult CBLDocument_CreateJSON(
     ffi.Pointer<CBLDocument> arg0,
   ) {
@@ -1029,7 +791,6 @@ class cblite {
   late final _CBLDocument_CreateJSON =
       _CBLDocument_CreateJSONPtr.asFunction<DartCBLDocument_CreateJSON>();
 
-  /// Sets a mutable document's properties from a JSON string.
   bool CBLDocument_SetJSON(
     ffi.Pointer<CBLDocument> arg0,
     FLSlice json,
@@ -1048,14 +809,6 @@ class cblite {
   late final _CBLDocument_SetJSON =
       _CBLDocument_SetJSONPtr.asFunction<DartCBLDocument_SetJSON>();
 
-  /// Returns the time, if any, at which a given document will expire and be
-  /// purged. Documents don't normally expire; you have to call \ref
-  /// CBLDatabase_SetDocumentExpiration to set a document's expiration time.
-  /// @warning <b>Deprecated :</b> Use CBLCollection_GetDocumentExpiration
-  /// instead. @param db The database. @param docID The ID of the document.
-  /// @param outError On failure, an error is written here. @return The
-  /// expiration time as a CBLTimestamp (milliseconds since Unix epoch), or 0 if
-  /// the document does not have an expiration, or -1 if the call failed.
   int CBLDatabase_GetDocumentExpiration(
     ffi.Pointer<CBLDatabase> db,
     FLSlice docID,
@@ -1075,12 +828,6 @@ class cblite {
       _CBLDatabase_GetDocumentExpirationPtr.asFunction<
           DartCBLDatabase_GetDocumentExpiration>();
 
-  /// Sets or clears the expiration time of a document. @warning <b>Deprecated
-  /// :</b> Use CBLCollection_SetDocumentExpiration instead. @param db The
-  /// database. @param docID The ID of the document. @param expiration The
-  /// expiration time as a CBLTimestamp (milliseconds since Unix epoch), or 0 if
-  /// the document should never expire. @param outError On failure, an error is
-  /// written here. @return True on success, false on failure.
   bool CBLDatabase_SetDocumentExpiration(
     ffi.Pointer<CBLDatabase> db,
     FLSlice docID,
@@ -1102,13 +849,6 @@ class cblite {
       _CBLDatabase_SetDocumentExpirationPtr.asFunction<
           DartCBLDatabase_SetDocumentExpiration>();
 
-  /// Registers a document change listener callback. It will be called after a
-  /// specific document is changed on disk. @warning <b>Deprecated :</b> Use
-  /// CBLCollection_AddDocumentChangeListener on the default collection instead.
-  /// @param db The database to observe. @param docID The ID of the document to
-  /// observe. @param listener The callback to be invoked. @param context An
-  /// opaque value that will be passed to the callback. @return A token to be
-  /// passed to \ref CBLListener_Remove when it's time to remove the listener.
   ffi.Pointer<CBLListenerToken> CBLDatabase_AddDocumentChangeListener(
     ffi.Pointer<CBLDatabase> db,
     FLString docID,
@@ -1130,8 +870,6 @@ class cblite {
       _CBLDatabase_AddDocumentChangeListenerPtr.asFunction<
           DartCBLDatabase_AddDocumentChangeListener>();
 
-  /// Creates a no-encoding type to use in CBLVectorIndexConfiguration; 4 bytes
-  /// per dimension, no data loss. @return A None encoding object.
   ffi.Pointer<CBLVectorEncoding> CBLVectorEncoding_CreateNone() {
     return _CBLVectorEncoding_CreateNone();
   }
@@ -1142,9 +880,6 @@ class cblite {
   late final _CBLVectorEncoding_CreateNone = _CBLVectorEncoding_CreateNonePtr
       .asFunction<DartCBLVectorEncoding_CreateNone>();
 
-  /// Creates a Scalar Quantizer encoding to use in CBLVectorIndexConfiguration.
-  /// @param type Scalar Quantizer Type. @return A Scalar Quantizer encoding
-  /// object.
   ffi.Pointer<CBLVectorEncoding> CBLVectorEncoding_CreateScalarQuantizer(
     int type,
   ) {
@@ -1160,10 +895,6 @@ class cblite {
       _CBLVectorEncoding_CreateScalarQuantizerPtr.asFunction<
           DartCBLVectorEncoding_CreateScalarQuantizer>();
 
-  /// Creates a Product Quantizer encoding to use in
-  /// CBLVectorIndexConfiguration. @param subquantizers Number of subquantizers.
-  /// Must be > 1 and a factor of vector dimensions. @param bits Number of bits.
-  /// Must be >= 4 and <= 12. @return A Product Quantizer encoding object.
   ffi.Pointer<CBLVectorEncoding> CBLVectorEncoding_CreateProductQuantizer(
     int subquantizers,
     int bits,
@@ -1181,8 +912,6 @@ class cblite {
       _CBLVectorEncoding_CreateProductQuantizerPtr.asFunction<
           DartCBLVectorEncoding_CreateProductQuantizer>();
 
-  /// Frees a CBLVectorEncoding object. The encoding object can be freed after
-  /// the index is created.
   void CBLVectorEncoding_Free(
     ffi.Pointer<CBLVectorEncoding> arg0,
   ) {
@@ -1197,19 +926,11 @@ class cblite {
   late final _CBLVectorEncoding_Free =
       _CBLVectorEncoding_FreePtr.asFunction<DartCBLVectorEncoding_Free>();
 
-  /// The default collection's name.
   late final ffi.Pointer<FLString> _kCBLDefaultCollectionName =
       _lookup<FLString>('kCBLDefaultCollectionName');
 
   FLString get kCBLDefaultCollectionName => _kCBLDefaultCollectionName.ref;
 
-  /// Returns the names of all existing scopes in the database. The scope exists
-  /// when there is at least one collection created under the scope. @note The
-  /// default scope will always exist, containing at least the default
-  /// collection. @note You are responsible for releasing the returned array.
-  /// @param db The database. @param outError On failure, the error will be
-  /// written here. @return The names of all existing scopes in the database, or
-  /// NULL if an error occurred.
   FLMutableArray CBLDatabase_ScopeNames(
     ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLError> outError,
@@ -1226,11 +947,6 @@ class cblite {
   late final _CBLDatabase_ScopeNames =
       _CBLDatabase_ScopeNamesPtr.asFunction<DartCBLDatabase_ScopeNames>();
 
-  /// Returns the names of all collections in the scope. @note You are
-  /// responsible for releasing the returned array. @param db The database.
-  /// @param scopeName The name of the scope. @param outError On failure, the
-  /// error will be written here. @return The names of all collections in the
-  /// scope, or NULL if an error occurred.
   FLMutableArray CBLDatabase_CollectionNames(
     ffi.Pointer<CBLDatabase> db,
     FLString scopeName,
@@ -1249,13 +965,6 @@ class cblite {
   late final _CBLDatabase_CollectionNames = _CBLDatabase_CollectionNamesPtr
       .asFunction<DartCBLDatabase_CollectionNames>();
 
-  /// Returns an existing scope with the given name. The scope exists when there
-  /// is at least one collection created under the scope. @note The default
-  /// scope will always exist, containing at least the default collection. @note
-  /// You are responsible for releasing the returned scope. @param db The
-  /// database. @param scopeName The name of the scope. @param outError On
-  /// failure, the error will be written here. @return A \ref CBLScope instance,
-  /// or NULL if the scope doesn't exist or an error occurred.
   ffi.Pointer<CBLScope> CBLDatabase_Scope(
     ffi.Pointer<CBLDatabase> db,
     FLString scopeName,
@@ -1273,12 +982,6 @@ class cblite {
   late final _CBLDatabase_Scope =
       _CBLDatabase_ScopePtr.asFunction<DartCBLDatabase_Scope>();
 
-  /// Returns the existing collection with the given name and scope. @note You
-  /// are responsible for releasing the returned collection. @param db The
-  /// database. @param collectionName The name of the collection. @param
-  /// scopeName The name of the scope. @param outError On failure, the error
-  /// will be written here. @return A \ref CBLCollection instance, or NULL if
-  /// the collection doesn't exist or an error occurred.
   ffi.Pointer<CBLCollection> CBLDatabase_Collection(
     ffi.Pointer<CBLDatabase> db,
     FLString collectionName,
@@ -1299,20 +1002,6 @@ class cblite {
   late final _CBLDatabase_Collection =
       _CBLDatabase_CollectionPtr.asFunction<DartCBLDatabase_Collection>();
 
-  /// Create a new collection. The naming rules of the collections and scopes
-  /// are as follows:
-  ///
-  /// - Must be between 1 and 251 characters in length.
-  /// - Can only contain the characters A-Z, a-z, 0-9, and the symbols \_, -,
-  ///   and %.
-  /// - Cannot start with \_ or %.
-  /// - Both scope and collection names are case sensitive. @note If the
-  ///   collection already exists, the existing collection will be returned.
-  ///   @note You are responsible for releasing the returned collection. @param
-  ///   db The database. @param collectionName The name of the collection.
-  ///   @param scopeName The name of the scope. @param outError On failure, the
-  ///   error will be written here. @return A \ref CBLCollection instance, or
-  ///   NULL if an error occurred.
   ffi.Pointer<CBLCollection> CBLDatabase_CreateCollection(
     ffi.Pointer<CBLDatabase> db,
     FLString collectionName,
@@ -1333,11 +1022,6 @@ class cblite {
   late final _CBLDatabase_CreateCollection = _CBLDatabase_CreateCollectionPtr
       .asFunction<DartCBLDatabase_CreateCollection>();
 
-  /// Delete an existing collection. @note The default collection cannot be
-  /// deleted. @param db The database. @param collectionName The name of the
-  /// collection. @param scopeName The name of the scope. @param outError On
-  /// failure, the error will be written here. @return True if success, or False
-  /// if an error occurred.
   bool CBLDatabase_DeleteCollection(
     ffi.Pointer<CBLDatabase> db,
     FLString collectionName,
@@ -1358,10 +1042,6 @@ class cblite {
   late final _CBLDatabase_DeleteCollection = _CBLDatabase_DeleteCollectionPtr
       .asFunction<DartCBLDatabase_DeleteCollection>();
 
-  /// Returns the default scope. @note You are responsible for releasing the
-  /// returned scope. @param db The database. @param outError On failure, the
-  /// error will be written here. @return A \ref CBLScope instance, or NULL if
-  /// an error occurred.
   ffi.Pointer<CBLScope> CBLDatabase_DefaultScope(
     ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLError> outError,
@@ -1378,10 +1058,6 @@ class cblite {
   late final _CBLDatabase_DefaultScope =
       _CBLDatabase_DefaultScopePtr.asFunction<DartCBLDatabase_DefaultScope>();
 
-  /// Returns the default collection. @note You are responsible for releasing
-  /// the returned collection. @param db The database. @param outError On
-  /// failure, the error will be written here. @return A \ref CBLCollection
-  /// instance, or NULL if an error occurred.
   ffi.Pointer<CBLCollection> CBLDatabase_DefaultCollection(
     ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLError> outError,
@@ -1398,9 +1074,6 @@ class cblite {
   late final _CBLDatabase_DefaultCollection = _CBLDatabase_DefaultCollectionPtr
       .asFunction<DartCBLDatabase_DefaultCollection>();
 
-  /// Returns the collection's scope. @note You are responsible for releasing
-  /// the returned scope. @param collection The collection. @return The scope of
-  /// the collection.
   ffi.Pointer<CBLScope> CBLCollection_Scope(
     ffi.Pointer<CBLCollection> collection,
   ) {
@@ -1415,8 +1088,6 @@ class cblite {
   late final _CBLCollection_Scope =
       _CBLCollection_ScopePtr.asFunction<DartCBLCollection_Scope>();
 
-  /// Returns the collection's name. @param collection The collection. @return
-  /// The name of the collection.
   FLString CBLCollection_Name(
     ffi.Pointer<CBLCollection> collection,
   ) {
@@ -1431,9 +1102,6 @@ class cblite {
   late final _CBLCollection_Name =
       _CBLCollection_NamePtr.asFunction<DartCBLCollection_Name>();
 
-  /// Returns the collection's fully qualified name in the
-  /// '<scope-name>.<collection-name>' format. @param collection The collection.
-  /// @return The fully qualified name of the collection.
   FLString CBLCollection_FullName(
     ffi.Pointer<CBLCollection> collection,
   ) {
@@ -1448,9 +1116,6 @@ class cblite {
   late final _CBLCollection_FullName =
       _CBLCollection_FullNamePtr.asFunction<DartCBLCollection_FullName>();
 
-  /// Returns the collection's database. @note The database object is owned by
-  /// the collection object; you do not need to release it. @param collection
-  /// The collection. @return The database of the collection.
   ffi.Pointer<CBLDatabase> CBLCollection_Database(
     ffi.Pointer<CBLCollection> collection,
   ) {
@@ -1465,8 +1130,6 @@ class cblite {
   late final _CBLCollection_Database =
       _CBLCollection_DatabasePtr.asFunction<DartCBLCollection_Database>();
 
-  /// Returns the number of documents in the collection. @param collection The
-  /// collection. @return the number of documents in the collection.
   int CBLCollection_Count(
     ffi.Pointer<CBLCollection> collection,
   ) {
@@ -1481,15 +1144,6 @@ class cblite {
   late final _CBLCollection_Count =
       _CBLCollection_CountPtr.asFunction<DartCBLCollection_Count>();
 
-  /// Reads a document from the collection, creating a new (immutable) \ref
-  /// CBLDocument object. Each call to this function creates a new object (which
-  /// must later be released.) @note If you are reading the document in order to
-  /// make changes to it, call CBLCollection_GetMutableDocument instead. @param
-  /// collection The collection. @param docID The ID of the document. @param
-  /// outError On failure, the error will be written here. (A nonexistent
-  /// document is not considered a failure; in that event the error code will be
-  /// zero.) @return A new \ref CBLDocument instance, or NULL if the doc doesn't
-  /// exist or an error occurred.
   ffi.Pointer<CBLDocument> CBLCollection_GetDocument(
     ffi.Pointer<CBLCollection> collection,
     FLString docID,
@@ -1508,14 +1162,6 @@ class cblite {
   late final _CBLCollection_GetDocument =
       _CBLCollection_GetDocumentPtr.asFunction<DartCBLCollection_GetDocument>();
 
-  /// Saves a (mutable) document to the collection. @warning If a newer revision
-  /// has been saved since the doc was loaded, it will be overwritten by this
-  /// one. This can lead to data loss! To avoid this, call \ref
-  /// CBLCollection_SaveDocumentWithConcurrencyControl or \ref
-  /// CBLCollection_SaveDocumentWithConflictHandler instead. @param collection
-  /// The collection to save to. @param doc The mutable document to save. @param
-  /// outError On failure, the error will be written here. @return True on
-  /// success, false on failure.
   bool CBLCollection_SaveDocument(
     ffi.Pointer<CBLCollection> collection,
     ffi.Pointer<CBLDocument> doc,
@@ -1534,15 +1180,6 @@ class cblite {
   late final _CBLCollection_SaveDocument = _CBLCollection_SaveDocumentPtr
       .asFunction<DartCBLCollection_SaveDocument>();
 
-  /// Saves a (mutable) document to the collection. If a conflicting revision
-  /// has been saved since \p doc was loaded, the \p concurrency parameter
-  /// specifies whether the save should fail, or the conflicting revision should
-  /// be overwritten with the revision being saved. If you need finer-grained
-  /// control, call \ref CBLCollection_SaveDocumentWithConflictHandler instead.
-  /// @param collection The collection to save to. @param doc The mutable
-  /// document to save. @param concurrency Conflict-handling strategy (fail or
-  /// overwrite). @param outError On failure, the error will be written here.
-  /// @return True on success, false on failure.
   bool CBLCollection_SaveDocumentWithConcurrencyControl(
     ffi.Pointer<CBLCollection> collection,
     ffi.Pointer<CBLDocument> doc,
@@ -1565,13 +1202,6 @@ class cblite {
       _CBLCollection_SaveDocumentWithConcurrencyControlPtr.asFunction<
           DartCBLCollection_SaveDocumentWithConcurrencyControl>();
 
-  /// Saves a (mutable) document to the collection, allowing for custom conflict
-  /// handling in the event that the document has been updated since \p doc was
-  /// loaded. @param collection The collection to save to. @param doc The
-  /// mutable document to save. @param conflictHandler The callback to be
-  /// invoked if there is a conflict. @param context An arbitrary value to be
-  /// passed to the \p conflictHandler. @param outError On failure, the error
-  /// will be written here. @return True on success, false on failure.
   bool CBLCollection_SaveDocumentWithConflictHandler(
     ffi.Pointer<CBLCollection> collection,
     ffi.Pointer<CBLDocument> doc,
@@ -1596,11 +1226,6 @@ class cblite {
       _CBLCollection_SaveDocumentWithConflictHandlerPtr.asFunction<
           DartCBLCollection_SaveDocumentWithConflictHandler>();
 
-  /// Deletes a document from the collection. Deletions are replicated. @warning
-  /// You are still responsible for releasing the CBLDocument. @param collection
-  /// The collection containing the document. @param document The document to
-  /// delete. @param outError On failure, the error will be written here.
-  /// @return True if the document was deleted, false if an error occurred.
   bool CBLCollection_DeleteDocument(
     ffi.Pointer<CBLCollection> collection,
     ffi.Pointer<CBLDocument> document,
@@ -1619,12 +1244,6 @@ class cblite {
   late final _CBLCollection_DeleteDocument = _CBLCollection_DeleteDocumentPtr
       .asFunction<DartCBLCollection_DeleteDocument>();
 
-  /// Deletes a document from the collection. Deletions are replicated. @warning
-  /// You are still responsible for releasing the CBLDocument. @param collection
-  /// The collection containing the document. @param document The document to
-  /// delete. @param concurrency Conflict-handling strategy. @param outError On
-  /// failure, the error will be written here. @return True if the document was
-  /// deleted, false if an error occurred.
   bool CBLCollection_DeleteDocumentWithConcurrencyControl(
     ffi.Pointer<CBLCollection> collection,
     ffi.Pointer<CBLDocument> document,
@@ -1647,16 +1266,6 @@ class cblite {
       _CBLCollection_DeleteDocumentWithConcurrencyControlPtr.asFunction<
           DartCBLCollection_DeleteDocumentWithConcurrencyControl>();
 
-  /// Purges a document. This removes all traces of the document from the
-  /// collection. Purges are _not_ replicated. If the document is changed on a
-  /// server, it will be re-created when pulled. @warning You are still
-  /// responsible for releasing the \ref CBLDocument reference. @note If you
-  /// don't have the document in memory already, \ref
-  /// CBLCollection_PurgeDocumentByID is a simpler shortcut. @param collection
-  /// The collection containing the document. @param document The document to
-  /// delete. @param outError On failure, the error will be written here.
-  /// @return True if the document was purged, false if it doesn't exist or the
-  /// purge failed.
   bool CBLCollection_PurgeDocument(
     ffi.Pointer<CBLCollection> collection,
     ffi.Pointer<CBLDocument> document,
@@ -1675,11 +1284,6 @@ class cblite {
   late final _CBLCollection_PurgeDocument = _CBLCollection_PurgeDocumentPtr
       .asFunction<DartCBLCollection_PurgeDocument>();
 
-  /// Purges a document, given only its ID. @note If no document with that ID
-  /// exists, this function will return false but the error code will be zero.
-  /// @param collection The collection. @param docID The document ID to purge.
-  /// @param outError On failure, the error will be written here. @return True
-  /// if the document was purged, false if it doesn't exist or the purge failed.
   bool CBLCollection_PurgeDocumentByID(
     ffi.Pointer<CBLCollection> collection,
     FLString docID,
@@ -1699,13 +1303,6 @@ class cblite {
       _CBLCollection_PurgeDocumentByIDPtr.asFunction<
           DartCBLCollection_PurgeDocumentByID>();
 
-  /// Returns the time, if any, at which a given document will expire and be
-  /// purged. Documents don't normally expire; you have to call \ref
-  /// CBLCollection_SetDocumentExpiration to set a document's expiration time.
-  /// @param collection The collection. @param docID The ID of the document.
-  /// @param outError On failure, an error is written here. @return The
-  /// expiration time as a CBLTimestamp (milliseconds since Unix epoch), or 0 if
-  /// the document does not have an expiration, or -1 if the call failed.
   int CBLCollection_GetDocumentExpiration(
     ffi.Pointer<CBLCollection> collection,
     FLSlice docID,
@@ -1725,11 +1322,6 @@ class cblite {
       _CBLCollection_GetDocumentExpirationPtr.asFunction<
           DartCBLCollection_GetDocumentExpiration>();
 
-  /// Sets or clears the expiration time of a document. @param collection The
-  /// collection. @param docID The ID of the document. @param expiration The
-  /// expiration time as a CBLTimestamp (milliseconds since Unix epoch), or 0 if
-  /// the document should never expire. @param outError On failure, an error is
-  /// written here. @return True on success, false on failure.
   bool CBLCollection_SetDocumentExpiration(
     ffi.Pointer<CBLCollection> collection,
     FLSlice docID,
@@ -1751,14 +1343,6 @@ class cblite {
       _CBLCollection_SetDocumentExpirationPtr.asFunction<
           DartCBLCollection_SetDocumentExpiration>();
 
-  /// Reads a document from the collection, in mutable form that can be updated
-  /// and saved. (This function is otherwise identical to \ref
-  /// CBLCollection_GetDocument.) @note You must release the document when
-  /// you're done with it. @param collection The collection. @param docID The ID
-  /// of the document. @param outError On failure, the error will be written
-  /// here. (A nonexistent document is not considered a failure; in that event
-  /// the error code will be zero.) @return A new \ref CBLDocument instance, or
-  /// NULL if the doc doesn't exist or an error occurred.
   ffi.Pointer<CBLDocument> CBLCollection_GetMutableDocument(
     ffi.Pointer<CBLCollection> collection,
     FLString docID,
@@ -1778,12 +1362,6 @@ class cblite {
       _CBLCollection_GetMutableDocumentPtr.asFunction<
           DartCBLCollection_GetMutableDocument>();
 
-  /// Creates a value index in the collection. If an identical index with that
-  /// name already exists, nothing happens (and no error is returned.) If a
-  /// non-identical index with that name already exists, it is deleted and
-  /// re-created. @param collection The collection. @param name The name of the
-  /// index. @param config The index configuration. @param outError On failure,
-  /// an error is written here. @return True on success, false on failure.
   bool CBLCollection_CreateValueIndex(
     ffi.Pointer<CBLCollection> collection,
     FLString name,
@@ -1805,12 +1383,6 @@ class cblite {
       _CBLCollection_CreateValueIndexPtr.asFunction<
           DartCBLCollection_CreateValueIndex>();
 
-  /// Creates a full-text index in the collection. If an identical index with
-  /// that name already exists, nothing happens (and no error is returned.) If a
-  /// non-identical index with that name already exists, it is deleted and
-  /// re-created. @param collection The collection. @param name The name of the
-  /// index. @param config The index configuration. @param outError On failure,
-  /// an error is written here. @return True on success, false on failure.
   bool CBLCollection_CreateFullTextIndex(
     ffi.Pointer<CBLCollection> collection,
     FLString name,
@@ -1832,12 +1404,6 @@ class cblite {
       _CBLCollection_CreateFullTextIndexPtr.asFunction<
           DartCBLCollection_CreateFullTextIndex>();
 
-  /// ENTERPRISE EDITION ONLY
-  ///
-  /// Creatres a vector index in the collection. If an identical index with that
-  /// name already exists, nothing happens (and no error is returned.) If a
-  /// non-identical index with that name already exists, it is deleted and
-  /// re-created.
   bool CBLCollection_CreateVectorIndex(
     ffi.Pointer<CBLCollection> collection,
     FLString name,
@@ -1859,9 +1425,6 @@ class cblite {
       _CBLCollection_CreateVectorIndexPtr.asFunction<
           DartCBLCollection_CreateVectorIndex>();
 
-  /// Deletes an index in the collection by name. @param collection The
-  /// collection. @param name The name of the index. @param outError On failure,
-  /// an error is written here. @return True on success, false on failure.
   bool CBLCollection_DeleteIndex(
     ffi.Pointer<CBLCollection> collection,
     FLString name,
@@ -1880,11 +1443,6 @@ class cblite {
   late final _CBLCollection_DeleteIndex =
       _CBLCollection_DeleteIndexPtr.asFunction<DartCBLCollection_DeleteIndex>();
 
-  /// Returns the names of the indexes in the collection, as a Fleece array of
-  /// strings. @note You are responsible for releasing the returned Fleece
-  /// array. @param collection The collection. @param outError On failure, an
-  /// error is written here. @return The index names in the collection, or NULL
-  /// if an error occurred.
   FLMutableArray CBLCollection_GetIndexNames(
     ffi.Pointer<CBLCollection> collection,
     ffi.Pointer<CBLError> outError,
@@ -1901,12 +1459,6 @@ class cblite {
   late final _CBLCollection_GetIndexNames = _CBLCollection_GetIndexNamesPtr
       .asFunction<DartCBLCollection_GetIndexNames>();
 
-  /// Returns an index object representing an existing index in the collection.
-  /// @note You are responsible for releasing the returned index object. @param
-  /// collection The collection. @param name The name of the index. @param
-  /// outError On failure, an error is written here. @return A \ref
-  /// CBLQueryIndex instance if the index exists, or NULL if the index doesn't
-  /// exist or an error occurred.
   ffi.Pointer<CBLQueryIndex> CBLCollection_GetIndex(
     ffi.Pointer<CBLCollection> collection,
     FLString name,
@@ -1925,12 +1477,6 @@ class cblite {
   late final _CBLCollection_GetIndex =
       _CBLCollection_GetIndexPtr.asFunction<DartCBLCollection_GetIndex>();
 
-  /// Registers a collection change listener callback. It will be called after
-  /// one or more documents are changed on disk. @param collection The
-  /// collection to observe. @param listener The callback to be invoked. @param
-  /// context An opaque value that will be passed to the callback. @return A
-  /// token to be passed to \ref CBLListener_Remove when it's time to remove the
-  /// listener.
   ffi.Pointer<CBLListenerToken> CBLCollection_AddChangeListener(
     ffi.Pointer<CBLCollection> collection,
     CBLCollectionChangeListener listener,
@@ -1950,12 +1496,6 @@ class cblite {
       _CBLCollection_AddChangeListenerPtr.asFunction<
           DartCBLCollection_AddChangeListener>();
 
-  /// Registers a document change listener callback. It will be called after a
-  /// specific document is changed on disk. @param collection The collection to
-  /// observe. @param docID The ID of the document to observe. @param listener
-  /// The callback to be invoked. @param context An opaque value that will be
-  /// passed to the callback. @return A token to be passed to \ref
-  /// CBLListener_Remove when it's time to remove the listener.
   ffi.Pointer<CBLListenerToken> CBLCollection_AddDocumentChangeListener(
     ffi.Pointer<CBLCollection> collection,
     FLString docID,
@@ -1977,16 +1517,6 @@ class cblite {
       _CBLCollection_AddDocumentChangeListenerPtr.asFunction<
           DartCBLCollection_AddDocumentChangeListener>();
 
-  /// ENTERPRISE EDITION ONLY
-  ///
-  /// Enables Vector Search extension by specifying the extension path to search
-  /// for the Vector Search extension library. This function must be called
-  /// before opening a database that intends to use the vector search extension.
-  /// @param path The file system path of the directory that contains the Vector
-  /// Search extension library. @param outError On return, will be set to the
-  /// error that occurred. @return True on success, false if there was an error.
-  /// @note Must be called before opening a database that intends to use the
-  /// vector search extension.
   bool CBL_EnableVectorSearch(
     FLString path,
     ffi.Pointer<CBLError> outError,
@@ -2003,7 +1533,6 @@ class cblite {
   late final _CBL_EnableVectorSearch =
       _CBL_EnableVectorSearchPtr.asFunction<DartCBL_EnableVectorSearch>();
 
-  /// Returns the default database configuration.
   CBLDatabaseConfiguration CBLDatabaseConfiguration_Default() {
     return _CBLDatabaseConfiguration_Default();
   }
@@ -2015,12 +1544,6 @@ class cblite {
       _CBLDatabaseConfiguration_DefaultPtr.asFunction<
           DartCBLDatabaseConfiguration_Default>();
 
-  /// Derives an encryption key from a password. If your UI uses passwords, call
-  /// this function to create the key used to encrypt the database. It is
-  /// designed for security, and deliberately runs slowly to make brute-force
-  /// attacks impractical. @param key The derived AES key will be stored here.
-  /// @param password The input password, which can be any data. @return True on
-  /// success, false if there was a problem deriving the key.
   bool CBLEncryptionKey_FromPassword(
     ffi.Pointer<CBLEncryptionKey> key,
     FLString password,
@@ -2037,12 +1560,6 @@ class cblite {
   late final _CBLEncryptionKey_FromPassword = _CBLEncryptionKey_FromPasswordPtr
       .asFunction<DartCBLEncryptionKey_FromPassword>();
 
-  /// VOLATILE API: Derives an encryption key from a password in a way that is
-  /// compatible with certain variants of Couchbase Lite in which a slightly
-  /// different hashing algorithm is used. The same notes apply as in
-  /// CBLEncryptionKey_FromPassword @param key The derived AES key will be
-  /// stored here. @param password The input password, which can be any data.
-  /// @return True on success, false if there was a problem deriving the key.
   bool CBLEncryptionKey_FromPasswordOld(
     ffi.Pointer<CBLEncryptionKey> key,
     FLString password,
@@ -2060,10 +1577,6 @@ class cblite {
       _CBLEncryptionKey_FromPasswordOldPtr.asFunction<
           DartCBLEncryptionKey_FromPasswordOld>();
 
-  /// Returns true if a database with the given name exists in the given
-  /// directory. @param name The database name (without the ".cblite2"
-  /// extension.) @param inDirectory The directory containing the database. If
-  /// NULL, `name` must be an absolute or relative path to the database.
   bool CBL_DatabaseExists(
     FLString name,
     FLString inDirectory,
@@ -2080,16 +1593,6 @@ class cblite {
   late final _CBL_DatabaseExists =
       _CBL_DatabaseExistsPtr.asFunction<DartCBL_DatabaseExists>();
 
-  /// Copies a database file to a new location, and assigns it a new internal
-  /// UUID to distinguish it from the original database when replicating. @param
-  /// fromPath The full filesystem path to the original database (including
-  /// extension). @param toName The new database name (without the ".cblite2"
-  /// extension.) @param config The database configuration (directory and
-  /// encryption option.) @param outError On return, will be set to the error
-  /// that occurred, if applicable. @note While a database is open, one or more
-  /// of its files may be in use. Attempting to copy a file, while it is in use,
-  /// will fail. We recommend that you close a database before attempting to
-  /// copy it.
   bool CBL_CopyDatabase(
     FLString fromPath,
     FLString toName,
@@ -2109,14 +1612,6 @@ class cblite {
   late final _CBL_CopyDatabase =
       _CBL_CopyDatabasePtr.asFunction<DartCBL_CopyDatabase>();
 
-  /// Deletes a database file. If the database file is open, an error is
-  /// returned. @param name The database name (without the ".cblite2"
-  /// extension.) @param inDirectory The directory containing the database. If
-  /// NULL, `name` must be an absolute or relative path to the database. @param
-  /// outError On return, will be set to the error that occurred, or a 0 code if
-  /// no error. @return True if the database was deleted, false if it doesn't
-  /// exist or deletion failed. (You can tell the last two cases apart by
-  /// looking at \p outError.)
   bool CBL_DeleteDatabase(
     FLString name,
     FLString inDirectory,
@@ -2135,14 +1630,6 @@ class cblite {
   late final _CBL_DeleteDatabase =
       _CBL_DeleteDatabasePtr.asFunction<DartCBL_DeleteDatabase>();
 
-  /// Opens a database, or creates it if it doesn't exist yet, returning a new
-  /// \ref CBLDatabase instance. It's OK to open the same database file multiple
-  /// times. Each \ref CBLDatabase instance is independent of the others (and
-  /// must be separately closed and released.) @param name The database name
-  /// (without the ".cblite2" extension.) @param config The database
-  /// configuration (directory and encryption option.) @param outError On
-  /// failure, the error will be written here. @return The new database object,
-  /// or NULL on failure.
   ffi.Pointer<CBLDatabase> CBLDatabase_Open(
     FLSlice name,
     ffi.Pointer<CBLDatabaseConfiguration> config,
@@ -2160,7 +1647,6 @@ class cblite {
   late final _CBLDatabase_Open =
       _CBLDatabase_OpenPtr.asFunction<DartCBLDatabase_Open>();
 
-  /// Closes an open database.
   bool CBLDatabase_Close(
     ffi.Pointer<CBLDatabase> arg0,
     ffi.Pointer<CBLError> outError,
@@ -2176,8 +1662,6 @@ class cblite {
   late final _CBLDatabase_Close =
       _CBLDatabase_ClosePtr.asFunction<DartCBLDatabase_Close>();
 
-  /// Closes and deletes a database. If there are any other connections to the
-  /// database, an error is returned.
   bool CBLDatabase_Delete(
     ffi.Pointer<CBLDatabase> arg0,
     ffi.Pointer<CBLError> outError,
@@ -2194,12 +1678,6 @@ class cblite {
   late final _CBLDatabase_Delete =
       _CBLDatabase_DeletePtr.asFunction<DartCBLDatabase_Delete>();
 
-  /// Begins a transaction. You **must** later call \ref
-  /// CBLDatabase_EndTransaction to commit or abort the transaction. @note
-  /// Multiple writes are much faster when grouped in a transaction. @note
-  /// Changes will not be visible to other CBLDatabase instances on the same
-  /// database until the transaction ends. @note Transactions can nest. Changes
-  /// are not committed until the outer transaction ends.
   bool CBLDatabase_BeginTransaction(
     ffi.Pointer<CBLDatabase> arg0,
     ffi.Pointer<CBLError> outError,
@@ -2216,7 +1694,6 @@ class cblite {
   late final _CBLDatabase_BeginTransaction = _CBLDatabase_BeginTransactionPtr
       .asFunction<DartCBLDatabase_BeginTransaction>();
 
-  /// Ends a transaction, either committing or aborting.
   bool CBLDatabase_EndTransaction(
     ffi.Pointer<CBLDatabase> arg0,
     bool commit,
@@ -2235,12 +1712,6 @@ class cblite {
   late final _CBLDatabase_EndTransaction = _CBLDatabase_EndTransactionPtr
       .asFunction<DartCBLDatabase_EndTransaction>();
 
-  /// Encrypts or decrypts a database, or changes its encryption key.
-  ///
-  /// If \p newKey is NULL, or its \p algorithm is \ref kCBLEncryptionNone, the
-  /// database will be decrypted. Otherwise the database will be encrypted with
-  /// that key; if it was already encrypted, it will be re-encrypted with the
-  /// new key.
   bool CBLDatabase_ChangeEncryptionKey(
     ffi.Pointer<CBLDatabase> arg0,
     ffi.Pointer<CBLEncryptionKey> newKey,
@@ -2260,7 +1731,6 @@ class cblite {
       _CBLDatabase_ChangeEncryptionKeyPtr.asFunction<
           DartCBLDatabase_ChangeEncryptionKey>();
 
-  /// Performs database maintenance.
   bool CBLDatabase_PerformMaintenance(
     ffi.Pointer<CBLDatabase> db,
     int type,
@@ -2280,7 +1750,6 @@ class cblite {
       _CBLDatabase_PerformMaintenancePtr.asFunction<
           DartCBLDatabase_PerformMaintenance>();
 
-  /// Returns the database's name.
   FLString CBLDatabase_Name(
     ffi.Pointer<CBLDatabase> arg0,
   ) {
@@ -2294,8 +1763,6 @@ class cblite {
   late final _CBLDatabase_Name =
       _CBLDatabase_NamePtr.asFunction<DartCBLDatabase_Name>();
 
-  /// Returns the database's full filesystem path, or null slice if the database
-  /// is closed or deleted.
   FLStringResult CBLDatabase_Path(
     ffi.Pointer<CBLDatabase> arg0,
   ) {
@@ -2309,9 +1776,6 @@ class cblite {
   late final _CBLDatabase_Path =
       _CBLDatabase_PathPtr.asFunction<DartCBLDatabase_Path>();
 
-  /// Returns the number of documents in the database, or zero if the database
-  /// is closed or deleted. @warning <b>Deprecated :</b> Use CBLCollection_Count
-  /// on the default collection instead.
   int CBLDatabase_Count(
     ffi.Pointer<CBLDatabase> arg0,
   ) {
@@ -2325,7 +1789,6 @@ class cblite {
   late final _CBLDatabase_Count =
       _CBLDatabase_CountPtr.asFunction<DartCBLDatabase_Count>();
 
-  /// Returns the database's configuration, as given when it was opened.
   CBLDatabaseConfiguration CBLDatabase_Config(
     ffi.Pointer<CBLDatabase> arg0,
   ) {
@@ -2340,11 +1803,6 @@ class cblite {
   late final _CBLDatabase_Config =
       _CBLDatabase_ConfigPtr.asFunction<DartCBLDatabase_Config>();
 
-  /// Creates a value index. Indexes are persistent. If an identical index with
-  /// that name already exists, nothing happens (and no error is returned.) If a
-  /// non-identical index with that name already exists, it is deleted and
-  /// re-created. @warning <b>Deprecated :</b> Use
-  /// CBLCollection_CreateValueIndex on the default collection instead.
   bool CBLDatabase_CreateValueIndex(
     ffi.Pointer<CBLDatabase> db,
     FLString name,
@@ -2365,11 +1823,6 @@ class cblite {
   late final _CBLDatabase_CreateValueIndex = _CBLDatabase_CreateValueIndexPtr
       .asFunction<DartCBLDatabase_CreateValueIndex>();
 
-  /// Creates a full-text index. Indexes are persistent. If an identical index
-  /// with that name already exists, nothing happens (and no error is returned.)
-  /// If a non-identical index with that name already exists, it is deleted and
-  /// re-created. @warning <b>Deprecated :</b> Use
-  /// CBLCollection_CreateFullTextIndex on the default collection instead.
   bool CBLDatabase_CreateFullTextIndex(
     ffi.Pointer<CBLDatabase> db,
     FLString name,
@@ -2391,8 +1844,6 @@ class cblite {
       _CBLDatabase_CreateFullTextIndexPtr.asFunction<
           DartCBLDatabase_CreateFullTextIndex>();
 
-  /// Deletes an index given its name. @warning <b>Deprecated :</b> Use
-  /// CBLCollection_DeleteIndex on the default collection instead.
   bool CBLDatabase_DeleteIndex(
     ffi.Pointer<CBLDatabase> db,
     FLString name,
@@ -2411,10 +1862,6 @@ class cblite {
   late final _CBLDatabase_DeleteIndex =
       _CBLDatabase_DeleteIndexPtr.asFunction<DartCBLDatabase_DeleteIndex>();
 
-  /// Returns the names of the indexes on this database, as a Fleece array of
-  /// strings. @note You are responsible for releasing the returned Fleece
-  /// array. @warning <b>Deprecated :</b> Use CBLCollection_GetIndexNames on the
-  /// default collection instead.
   FLArray CBLDatabase_GetIndexNames(
     ffi.Pointer<CBLDatabase> db,
   ) {
@@ -2429,13 +1876,6 @@ class cblite {
   late final _CBLDatabase_GetIndexNames =
       _CBLDatabase_GetIndexNamesPtr.asFunction<DartCBLDatabase_GetIndexNames>();
 
-  /// Registers a default collection change listener callback. It will be called
-  /// after one or more documents are changed on disk. @warning <b>Deprecated
-  /// :</b> Use CBLCollection_AddChangeListener on the default collection
-  /// instead. @param db The database to observe. @param listener The callback
-  /// to be invoked. @param context An opaque value that will be passed to the
-  /// callback. @return A token to be passed to \ref CBLListener_Remove when
-  /// it's time to remove the listener.
   ffi.Pointer<CBLListenerToken> CBLDatabase_AddChangeListener(
     ffi.Pointer<CBLDatabase> db,
     CBLDatabaseChangeListener listener,
@@ -2454,13 +1894,6 @@ class cblite {
   late final _CBLDatabase_AddChangeListener = _CBLDatabase_AddChangeListenerPtr
       .asFunction<DartCBLDatabase_AddChangeListener>();
 
-  /// Switches the database to buffered-notification mode. Notifications for
-  /// objects belonging to this database (documents, queries, replicators, and
-  /// of course the database) will not be called immediately; your \ref
-  /// CBLNotificationsReadyCallback will be called instead. @param db The
-  /// database whose notifications are to be buffered. @param callback The
-  /// function to be called when a notification is available. @param context An
-  /// arbitrary value that will be passed to the callback.
   void CBLDatabase_BufferNotifications(
     ffi.Pointer<CBLDatabase> db,
     CBLNotificationsReadyCallback callback,
@@ -2480,8 +1913,6 @@ class cblite {
       _CBLDatabase_BufferNotificationsPtr.asFunction<
           DartCBLDatabase_BufferNotifications>();
 
-  /// Immediately issues all pending notifications for this database, by calling
-  /// their listener callbacks.
   void CBLDatabase_SendNotifications(
     ffi.Pointer<CBLDatabase> db,
   ) {
@@ -2496,21 +1927,11 @@ class cblite {
   late final _CBLDatabase_SendNotifications = _CBLDatabase_SendNotificationsPtr
       .asFunction<DartCBLDatabase_SendNotifications>();
 
-  /// The name of the HTTP cookie used by Sync Gateway to store session keys.
   late final ffi.Pointer<FLString> _kCBLAuthDefaultCookieName =
       _lookup<FLString>('kCBLAuthDefaultCookieName');
 
   FLString get kCBLAuthDefaultCookieName => _kCBLAuthDefaultCookieName.ref;
 
-  /// Creates a new endpoint representing a server-based database at the given
-  /// URL. The URL's scheme must be `ws` or `wss`, it must of course have a
-  /// valid hostname, and its path must be the name of the database on that
-  /// server.
-  ///
-  /// The port can be omitted; it defaults to 80 for `ws` and 443 for `wss`. For
-  /// example: `wss://example.org/dbname`.
-  ///
-  /// If an invalid endpoint URL is specified, an error will be returned.
   ffi.Pointer<CBLEndpoint> CBLEndpoint_CreateWithURL(
     FLString url,
     ffi.Pointer<CBLError> outError,
@@ -2527,8 +1948,6 @@ class cblite {
   late final _CBLEndpoint_CreateWithURL =
       _CBLEndpoint_CreateWithURLPtr.asFunction<DartCBLEndpoint_CreateWithURL>();
 
-  /// Creates a new endpoint representing another local database. (Enterprise
-  /// Edition only.)
   ffi.Pointer<CBLEndpoint> CBLEndpoint_CreateWithLocalDB(
     ffi.Pointer<CBLDatabase> arg0,
   ) {
@@ -2543,7 +1962,6 @@ class cblite {
   late final _CBLEndpoint_CreateWithLocalDB = _CBLEndpoint_CreateWithLocalDBPtr
       .asFunction<DartCBLEndpoint_CreateWithLocalDB>();
 
-  /// Frees a CBLEndpoint object.
   void CBLEndpoint_Free(
     ffi.Pointer<CBLEndpoint> arg0,
   ) {
@@ -2557,7 +1975,6 @@ class cblite {
   late final _CBLEndpoint_Free =
       _CBLEndpoint_FreePtr.asFunction<DartCBLEndpoint_Free>();
 
-  /// Creates an authenticator for HTTP Basic (username/password) auth.
   ffi.Pointer<CBLAuthenticator> CBLAuth_CreatePassword(
     FLString username,
     FLString password,
@@ -2574,8 +1991,6 @@ class cblite {
   late final _CBLAuth_CreatePassword =
       _CBLAuth_CreatePasswordPtr.asFunction<DartCBLAuth_CreatePassword>();
 
-  /// Creates an authenticator using a Couchbase Sync Gateway login session
-  /// identifier, and optionally a cookie name (pass NULL for the default.)
   ffi.Pointer<CBLAuthenticator> CBLAuth_CreateSession(
     FLString sessionID,
     FLString cookieName,
@@ -2592,7 +2007,6 @@ class cblite {
   late final _CBLAuth_CreateSession =
       _CBLAuth_CreateSessionPtr.asFunction<DartCBLAuth_CreateSession>();
 
-  /// Frees a CBLAuthenticator object.
   void CBLAuth_Free(
     ffi.Pointer<CBLAuthenticator> arg0,
   ) {
@@ -2605,7 +2019,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeCBLAuth_Free>>('CBLAuth_Free');
   late final _CBLAuth_Free = _CBLAuth_FreePtr.asFunction<DartCBLAuth_Free>();
 
-  /// Default conflict resolver. This always returns `localDocument`.
   late final ffi.Pointer<CBLConflictResolver> _CBLDefaultConflictResolver =
       _lookup<CBLConflictResolver>('CBLDefaultConflictResolver');
 
@@ -2615,7 +2028,6 @@ class cblite {
   set CBLDefaultConflictResolver(CBLConflictResolver value) =>
       _CBLDefaultConflictResolver.value = value;
 
-  /// Creates a replicator with the given configuration.
   ffi.Pointer<CBLReplicator> CBLReplicator_Create(
     ffi.Pointer<CBLReplicatorConfiguration> arg0,
     ffi.Pointer<CBLError> outError,
@@ -2632,7 +2044,6 @@ class cblite {
   late final _CBLReplicator_Create =
       _CBLReplicator_CreatePtr.asFunction<DartCBLReplicator_Create>();
 
-  /// Returns the configuration of an existing replicator.
   ffi.Pointer<CBLReplicatorConfiguration> CBLReplicator_Config(
     ffi.Pointer<CBLReplicator> arg0,
   ) {
@@ -2647,14 +2058,6 @@ class cblite {
   late final _CBLReplicator_Config =
       _CBLReplicator_ConfigPtr.asFunction<DartCBLReplicator_Config>();
 
-  /// Starts a replicator, asynchronously. Does nothing if it's already started.
-  /// @note Replicators cannot be started from within a database's transaction.
-  /// @param replicator The replicator instance. @param resetCheckpoint If true,
-  /// the persistent saved state ("checkpoint") for this replication will be
-  /// discarded, causing it to re-scan all documents. This significantly
-  /// increases time and bandwidth (redundant docs are not transferred, but
-  /// their IDs are) but can resolve unexpected problems with missing documents
-  /// if one side or the other has gotten out of sync.
   void CBLReplicator_Start(
     ffi.Pointer<CBLReplicator> replicator,
     bool resetCheckpoint,
@@ -2671,11 +2074,6 @@ class cblite {
   late final _CBLReplicator_Start =
       _CBLReplicator_StartPtr.asFunction<DartCBLReplicator_Start>();
 
-  /// Stops a running replicator, asynchronously. Does nothing if it's not
-  /// already started. The replicator will call your \ref
-  /// CBLReplicatorChangeListener with an activity level of \ref
-  /// kCBLReplicatorStopped after it stops. Until then, consider it still
-  /// active.
   void CBLReplicator_Stop(
     ffi.Pointer<CBLReplicator> arg0,
   ) {
@@ -2690,12 +2088,6 @@ class cblite {
   late final _CBLReplicator_Stop =
       _CBLReplicator_StopPtr.asFunction<DartCBLReplicator_Stop>();
 
-  /// Informs the replicator whether it's considered possible to reach the
-  /// remote host with the current network configuration. The default value is
-  /// true. This only affects the replicator's behavior while it's in the
-  /// Offline state: Setting it to false will cancel any pending retry and
-  /// prevent future automatic retries. Setting it back to true will initiate an
-  /// immediate retry.
   void CBLReplicator_SetHostReachable(
     ffi.Pointer<CBLReplicator> arg0,
     bool reachable,
@@ -2713,11 +2105,6 @@ class cblite {
       _CBLReplicator_SetHostReachablePtr.asFunction<
           DartCBLReplicator_SetHostReachable>();
 
-  /// Puts the replicator in or out of "suspended" state. The default is false.
-  /// Setting suspended=true causes the replicator to disconnect and enter
-  /// Offline state; it will not attempt to reconnect while it's suspended.
-  /// Setting suspended=false causes the replicator to attempt to reconnect,
-  /// _if_ it was connected when suspended, and is still in Offline state.
   void CBLReplicator_SetSuspended(
     ffi.Pointer<CBLReplicator> repl,
     bool suspended,
@@ -2734,7 +2121,6 @@ class cblite {
   late final _CBLReplicator_SetSuspended = _CBLReplicator_SetSuspendedPtr
       .asFunction<DartCBLReplicator_SetSuspended>();
 
-  /// Returns the replicator's current status.
   CBLReplicatorStatus CBLReplicator_Status(
     ffi.Pointer<CBLReplicator> arg0,
   ) {
@@ -2749,22 +2135,6 @@ class cblite {
   late final _CBLReplicator_Status =
       _CBLReplicator_StatusPtr.asFunction<DartCBLReplicator_Status>();
 
-  /// Indicates which documents in the default collection have local changes
-  /// that have not yet been pushed to the server by this replicator. This is of
-  /// course a snapshot, that will go out of date as the replicator makes
-  /// progress and/or documents are saved locally.
-  ///
-  /// The result is, effectively, a set of document IDs: a dictionary whose keys
-  /// are the IDs and values are `true`. If there are no pending documents, the
-  /// dictionary is empty. On error, NULL is returned.
-  ///
-  /// @note This function can be called on a stopped or un-started replicator.
-  /// @note Documents that would never be pushed by this replicator, due to its
-  /// configuration's `pushFilter` or `docIDs`, are ignored. @warning You are
-  /// responsible for releasing the returned array via \ref FLValue_Release.
-  /// @warning If the default collection is not part of the replication, a NULL
-  /// with an error will be returned. @warning <b>Deprecated :</b> Use
-  /// CBLReplicator_PendingDocumentIDs2 instead.
   FLDict CBLReplicator_PendingDocumentIDs(
     ffi.Pointer<CBLReplicator> arg0,
     ffi.Pointer<CBLError> outError,
@@ -2782,18 +2152,6 @@ class cblite {
       _CBLReplicator_PendingDocumentIDsPtr.asFunction<
           DartCBLReplicator_PendingDocumentIDs>();
 
-  /// Indicates whether the document in the default collection with the given ID
-  /// has local changes that have not yet been pushed to the server by this
-  /// replicator.
-  ///
-  /// This is equivalent to, but faster than, calling \ref
-  /// CBLReplicator*PendingDocumentIDs and checking whether the result contains
-  /// \p docID. See that function's documentation for details. @note A `false`
-  /// result means the document is not pending, \_or* there was an error. To
-  /// tell the difference, compare the error code to zero. @warning If the
-  /// default collection is not part of the replication, a NULL with an error
-  /// will be returned. @warning <b>Deprecated :</b> Use
-  /// CBLReplicator_IsDocumentPending2 instead.
   bool CBLReplicator_IsDocumentPending(
     ffi.Pointer<CBLReplicator> repl,
     FLString docID,
@@ -2813,16 +2171,6 @@ class cblite {
       _CBLReplicator_IsDocumentPendingPtr.asFunction<
           DartCBLReplicator_IsDocumentPending>();
 
-  /// Indicates which documents in the given collection have local changes that
-  /// have not yet been pushed to the server by this replicator. This is of
-  /// course a snapshot, that will go out of date as the replicator makes
-  /// progress and/or documents are saved locally.
-  ///
-  /// The result is, effectively, a set of document IDs: a dictionary whose keys
-  /// are the IDs and values are `true`. If there are no pending documents, the
-  /// dictionary is empty. On error, NULL is returned. @warning If the given
-  /// collection is not part of the replication, a NULL with an error will be
-  /// returned.
   FLDict CBLReplicator_PendingDocumentIDs2(
     ffi.Pointer<CBLReplicator> arg0,
     ffi.Pointer<CBLCollection> collection,
@@ -2842,17 +2190,6 @@ class cblite {
       _CBLReplicator_PendingDocumentIDs2Ptr.asFunction<
           DartCBLReplicator_PendingDocumentIDs2>();
 
-  /// Indicates whether the document with the given ID in the given collection
-  /// has local changes that have not yet been pushed to the server by this
-  /// replicator.
-  ///
-  /// This is equivalent to, but faster than, calling \ref
-  /// CBLReplicator*PendingDocumentIDs2 and checking whether the result contains
-  /// \p docID. See that function's documentation for details. @note A `false`
-  /// result means the document is not pending, \_or* there was an error. To
-  /// tell the difference, compare the error code to zero. @warning If the given
-  /// collection is not part of the replication, a NULL with an error will be
-  /// returned.
   bool CBLReplicator_IsDocumentPending2(
     ffi.Pointer<CBLReplicator> repl,
     FLString docID,
@@ -2874,8 +2211,6 @@ class cblite {
       _CBLReplicator_IsDocumentPending2Ptr.asFunction<
           DartCBLReplicator_IsDocumentPending2>();
 
-  /// Registers a listener that will be called when the replicator's status
-  /// changes.
   ffi.Pointer<CBLListenerToken> CBLReplicator_AddChangeListener(
     ffi.Pointer<CBLReplicator> arg0,
     CBLReplicatorChangeListener arg1,
@@ -2895,7 +2230,6 @@ class cblite {
       _CBLReplicator_AddChangeListenerPtr.asFunction<
           DartCBLReplicator_AddChangeListener>();
 
-  /// Registers a listener that will be called when documents are replicated.
   ffi.Pointer<CBLListenerToken> CBLReplicator_AddDocumentReplicationListener(
     ffi.Pointer<CBLReplicator> arg0,
     CBLDocumentReplicationListener arg1,
@@ -2916,70 +2250,53 @@ class cblite {
       _CBLReplicator_AddDocumentReplicationListenerPtr.asFunction<
           DartCBLReplicator_AddDocumentReplicationListener>();
 
-  /// [false] Plaintext is not used, and instead binary encoding is used in log
-  /// files
   late final ffi.Pointer<ffi.Bool> _kCBLDefaultLogFileUsePlaintext =
       _lookup<ffi.Bool>('kCBLDefaultLogFileUsePlaintext');
 
   bool get kCBLDefaultLogFileUsePlaintext =>
       _kCBLDefaultLogFileUsePlaintext.value;
 
-  /// [false] Plaintext is not used, and instead binary encoding is used in log
-  /// files @warning <b>Deprecated :</b> Use kCBLDefaultLogFileUsePlaintext
-  /// instead.
   late final ffi.Pointer<ffi.Bool> _kCBLDefaultLogFileUsePlainText =
       _lookup<ffi.Bool>('kCBLDefaultLogFileUsePlainText');
 
   bool get kCBLDefaultLogFileUsePlainText =>
       _kCBLDefaultLogFileUsePlainText.value;
 
-  /// [524288] 512 KiB for the size of a log file
   late final ffi.Pointer<ffi.Size> _kCBLDefaultLogFileMaxSize =
       _lookup<ffi.Size>('kCBLDefaultLogFileMaxSize');
 
   int get kCBLDefaultLogFileMaxSize => _kCBLDefaultLogFileMaxSize.value;
 
-  /// [1] 1 rotated file present (2 total, including the currently active log
-  /// file)
   late final ffi.Pointer<ffi.Uint32> _kCBLDefaultLogFileMaxRotateCount =
       _lookup<ffi.Uint32>('kCBLDefaultLogFileMaxRotateCount');
 
   int get kCBLDefaultLogFileMaxRotateCount =>
       _kCBLDefaultLogFileMaxRotateCount.value;
 
-  /// [false] Accents and ligatures are not ignored when indexing via full text
-  /// search
   late final ffi.Pointer<ffi.Bool> _kCBLDefaultFullTextIndexIgnoreAccents =
       _lookup<ffi.Bool>('kCBLDefaultFullTextIndexIgnoreAccents');
 
   bool get kCBLDefaultFullTextIndexIgnoreAccents =>
       _kCBLDefaultFullTextIndexIgnoreAccents.value;
 
-  /// [kCBLReplicatorTypePushAndPull] Perform bidirectional replication
   late final ffi.Pointer<CBLReplicatorType> _kCBLDefaultReplicatorType =
       _lookup<CBLReplicatorType>('kCBLDefaultReplicatorType');
 
   DartCBLReplicatorType get kCBLDefaultReplicatorType =>
       _kCBLDefaultReplicatorType.value;
 
-  /// [false] One-shot replication is used, and will stop once all initial
-  /// changes are processed
   late final ffi.Pointer<ffi.Bool> _kCBLDefaultReplicatorContinuous =
       _lookup<ffi.Bool>('kCBLDefaultReplicatorContinuous');
 
   bool get kCBLDefaultReplicatorContinuous =>
       _kCBLDefaultReplicatorContinuous.value;
 
-  /// [300] A heartbeat messages is sent every 300 seconds to keep the
-  /// connection alive
   late final ffi.Pointer<ffi.UnsignedInt> _kCBLDefaultReplicatorHeartbeat =
       _lookup<ffi.UnsignedInt>('kCBLDefaultReplicatorHeartbeat');
 
   int get kCBLDefaultReplicatorHeartbeat =>
       _kCBLDefaultReplicatorHeartbeat.value;
 
-  /// [10] When replicator is not continuous, after 10 failed attempts give up
-  /// on the replication
   late final ffi.Pointer<ffi.UnsignedInt>
       _kCBLDefaultReplicatorMaxAttemptsSingleShot =
       _lookup<ffi.UnsignedInt>('kCBLDefaultReplicatorMaxAttemptsSingleShot');
@@ -2987,8 +2304,6 @@ class cblite {
   int get kCBLDefaultReplicatorMaxAttemptsSingleShot =>
       _kCBLDefaultReplicatorMaxAttemptsSingleShot.value;
 
-  /// [UINT_MAX] When replicator is continuous, never give up unless explicitly
-  /// stopped
   late final ffi.Pointer<ffi.UnsignedInt>
       _kCBLDefaultReplicatorMaxAttemptsContinuous =
       _lookup<ffi.UnsignedInt>('kCBLDefaultReplicatorMaxAttemptsContinuous');
@@ -2996,7 +2311,6 @@ class cblite {
   int get kCBLDefaultReplicatorMaxAttemptsContinuous =>
       _kCBLDefaultReplicatorMaxAttemptsContinuous.value;
 
-  /// [300] Max wait time between retry attempts in seconds
   late final ffi.Pointer<ffi.UnsignedInt>
       _kCBLDefaultReplicatorMaxAttemptsWaitTime =
       _lookup<ffi.UnsignedInt>('kCBLDefaultReplicatorMaxAttemptsWaitTime');
@@ -3004,8 +2318,6 @@ class cblite {
   int get kCBLDefaultReplicatorMaxAttemptsWaitTime =>
       _kCBLDefaultReplicatorMaxAttemptsWaitTime.value;
 
-  /// [300] Max wait time between retry attempts in seconds @warning
-  /// <b>Deprecated :</b> Use kCBLDefaultReplicatorMaxAttemptsWaitTime instead.
   late final ffi.Pointer<ffi.UnsignedInt>
       _kCBLDefaultReplicatorMaxAttemptWaitTime =
       _lookup<ffi.UnsignedInt>('kCBLDefaultReplicatorMaxAttemptWaitTime');
@@ -3013,29 +2325,23 @@ class cblite {
   int get kCBLDefaultReplicatorMaxAttemptWaitTime =>
       _kCBLDefaultReplicatorMaxAttemptWaitTime.value;
 
-  /// [false] Purge documents when a user loses access
   late final ffi.Pointer<ffi.Bool> _kCBLDefaultReplicatorDisableAutoPurge =
       _lookup<ffi.Bool>('kCBLDefaultReplicatorDisableAutoPurge');
 
   bool get kCBLDefaultReplicatorDisableAutoPurge =>
       _kCBLDefaultReplicatorDisableAutoPurge.value;
 
-  /// [false] Whether or not a replicator only accepts cookies for the sender's
-  /// parent domains
   late final ffi.Pointer<ffi.Bool> _kCBLDefaultReplicatorAcceptParentCookies =
       _lookup<ffi.Bool>('kCBLDefaultReplicatorAcceptParentCookies');
 
   bool get kCBLDefaultReplicatorAcceptParentCookies =>
       _kCBLDefaultReplicatorAcceptParentCookies.value;
 
-  /// [false] Vectors are not lazily indexed, by default
   late final ffi.Pointer<ffi.Bool> _kCBLDefaultVectorIndexLazy =
       _lookup<ffi.Bool>('kCBLDefaultVectorIndexLazy');
 
   bool get kCBLDefaultVectorIndexLazy => _kCBLDefaultVectorIndexLazy.value;
 
-  /// [kCBLDistanceMetricEuclideanSquared] By default, vectors are compared
-  /// using Squared Euclidean metric.
   late final ffi.Pointer<CBLDistanceMetric>
       _kCBLDefaultVectorIndexDistanceMetric =
       _lookup<CBLDistanceMetric>('kCBLDefaultVectorIndexDistanceMetric');
@@ -3043,8 +2349,6 @@ class cblite {
   DartCBLDistanceMetric get kCBLDefaultVectorIndexDistanceMetric =>
       _kCBLDefaultVectorIndexDistanceMetric.value;
 
-  /// [0] By default, the value will be determined based on the number of
-  /// centroids, encoding types, and the encoding parameters.
   late final ffi.Pointer<ffi.UnsignedInt>
       _kCBLDefaultVectorIndexMinTrainingSize =
       _lookup<ffi.UnsignedInt>('kCBLDefaultVectorIndexMinTrainingSize');
@@ -3052,8 +2356,6 @@ class cblite {
   int get kCBLDefaultVectorIndexMinTrainingSize =>
       _kCBLDefaultVectorIndexMinTrainingSize.value;
 
-  /// [0] By default, the value will be determined based on the number of
-  /// centroids, encoding types, and the encoding parameters
   late final ffi.Pointer<ffi.UnsignedInt>
       _kCBLDefaultVectorIndexMaxTrainingSize =
       _lookup<ffi.UnsignedInt>('kCBLDefaultVectorIndexMaxTrainingSize');
@@ -3061,27 +2363,22 @@ class cblite {
   int get kCBLDefaultVectorIndexMaxTrainingSize =>
       _kCBLDefaultVectorIndexMaxTrainingSize.value;
 
-  /// [0] By default, the value will be determined based on the number of
-  /// centroids.
   late final ffi.Pointer<ffi.UnsignedInt> _kCBLDefaultVectorIndexNumProbes =
       _lookup<ffi.UnsignedInt>('kCBLDefaultVectorIndexNumProbes');
 
   int get kCBLDefaultVectorIndexNumProbes =>
       _kCBLDefaultVectorIndexNumProbes.value;
 
-  /// < `"encryptable"`
   late final ffi.Pointer<FLSlice> _kCBLEncryptableType =
       _lookup<FLSlice>('kCBLEncryptableType');
 
   FLSlice get kCBLEncryptableType => _kCBLEncryptableType.ref;
 
-  /// < `"value"`
   late final ffi.Pointer<FLSlice> _kCBLEncryptableValueProperty =
       _lookup<FLSlice>('kCBLEncryptableValueProperty');
 
   FLSlice get kCBLEncryptableValueProperty => _kCBLEncryptableValueProperty.ref;
 
-  /// Creates CBLEncryptable object with null value.
   ffi.Pointer<CBLEncryptable> CBLEncryptable_CreateWithNull() {
     return _CBLEncryptable_CreateWithNull();
   }
@@ -3092,7 +2389,6 @@ class cblite {
   late final _CBLEncryptable_CreateWithNull = _CBLEncryptable_CreateWithNullPtr
       .asFunction<DartCBLEncryptable_CreateWithNull>();
 
-  /// Creates CBLEncryptable object with a boolean value.
   ffi.Pointer<CBLEncryptable> CBLEncryptable_CreateWithBool(
     bool value,
   ) {
@@ -3107,7 +2403,6 @@ class cblite {
   late final _CBLEncryptable_CreateWithBool = _CBLEncryptable_CreateWithBoolPtr
       .asFunction<DartCBLEncryptable_CreateWithBool>();
 
-  /// Creates CBLEncryptable object with an int value.
   ffi.Pointer<CBLEncryptable> CBLEncryptable_CreateWithInt(
     int value,
   ) {
@@ -3122,7 +2417,6 @@ class cblite {
   late final _CBLEncryptable_CreateWithInt = _CBLEncryptable_CreateWithIntPtr
       .asFunction<DartCBLEncryptable_CreateWithInt>();
 
-  /// Creates CBLEncryptable object with an unsigned int value.
   ffi.Pointer<CBLEncryptable> CBLEncryptable_CreateWithUInt(
     int value,
   ) {
@@ -3137,7 +2431,6 @@ class cblite {
   late final _CBLEncryptable_CreateWithUInt = _CBLEncryptable_CreateWithUIntPtr
       .asFunction<DartCBLEncryptable_CreateWithUInt>();
 
-  /// Creates CBLEncryptable object with a float value.
   ffi.Pointer<CBLEncryptable> CBLEncryptable_CreateWithFloat(
     double value,
   ) {
@@ -3153,7 +2446,6 @@ class cblite {
       _CBLEncryptable_CreateWithFloatPtr.asFunction<
           DartCBLEncryptable_CreateWithFloat>();
 
-  /// Creates CBLEncryptable object with a double value.
   ffi.Pointer<CBLEncryptable> CBLEncryptable_CreateWithDouble(
     double value,
   ) {
@@ -3169,7 +2461,6 @@ class cblite {
       _CBLEncryptable_CreateWithDoublePtr.asFunction<
           DartCBLEncryptable_CreateWithDouble>();
 
-  /// Creates CBLEncryptable object with a string value.
   ffi.Pointer<CBLEncryptable> CBLEncryptable_CreateWithString(
     FLString value,
   ) {
@@ -3185,7 +2476,6 @@ class cblite {
       _CBLEncryptable_CreateWithStringPtr.asFunction<
           DartCBLEncryptable_CreateWithString>();
 
-  /// Creates CBLEncryptable object with an FLValue value.
   ffi.Pointer<CBLEncryptable> CBLEncryptable_CreateWithValue(
     FLValue value,
   ) {
@@ -3201,7 +2491,6 @@ class cblite {
       _CBLEncryptable_CreateWithValuePtr.asFunction<
           DartCBLEncryptable_CreateWithValue>();
 
-  /// Creates CBLEncryptable object with an FLArray value.
   ffi.Pointer<CBLEncryptable> CBLEncryptable_CreateWithArray(
     FLArray value,
   ) {
@@ -3217,7 +2506,6 @@ class cblite {
       _CBLEncryptable_CreateWithArrayPtr.asFunction<
           DartCBLEncryptable_CreateWithArray>();
 
-  /// Creates CBLEncryptable object with an FLDict value.
   ffi.Pointer<CBLEncryptable> CBLEncryptable_CreateWithDict(
     FLDict value,
   ) {
@@ -3232,7 +2520,6 @@ class cblite {
   late final _CBLEncryptable_CreateWithDict = _CBLEncryptable_CreateWithDictPtr
       .asFunction<DartCBLEncryptable_CreateWithDict>();
 
-  /// Returns the value to be encrypted by the push replicator.
   FLValue CBLEncryptable_Value(
     ffi.Pointer<CBLEncryptable> encryptable,
   ) {
@@ -3247,7 +2534,6 @@ class cblite {
   late final _CBLEncryptable_Value =
       _CBLEncryptable_ValuePtr.asFunction<DartCBLEncryptable_Value>();
 
-  /// Returns the dictionary format of the \ref CBLEncryptable object.
   FLDict CBLEncryptable_Properties(
     ffi.Pointer<CBLEncryptable> encryptable,
   ) {
@@ -3262,7 +2548,6 @@ class cblite {
   late final _CBLEncryptable_Properties =
       _CBLEncryptable_PropertiesPtr.asFunction<DartCBLEncryptable_Properties>();
 
-  /// Checks whether the given dictionary is a \ref CBLEncryptable or not.
   bool FLDict_IsEncryptableValue(
     FLDict arg0,
   ) {
@@ -3277,10 +2562,6 @@ class cblite {
   late final _FLDict_IsEncryptableValue =
       _FLDict_IsEncryptableValuePtr.asFunction<DartFLDict_IsEncryptableValue>();
 
-  /// Returns a \ref CBLEncryptable object corresponding to the given
-  /// encryptable dictionary in a document or NULL if the dictionary is not a
-  /// \ref CBLEncryptable. \note The returned CBLEncryptable object will be
-  /// released when its document is released.
   ffi.Pointer<CBLEncryptable> FLDict_GetEncryptableValue(
     FLDict encryptableDict,
   ) {
@@ -3295,7 +2576,6 @@ class cblite {
   late final _FLDict_GetEncryptableValue = _FLDict_GetEncryptableValuePtr
       .asFunction<DartFLDict_GetEncryptableValue>();
 
-  /// Set a \ref CBLEncryptable's dictionary into a mutable dictionary's slot.
   void FLSlot_SetEncryptableValue(
     FLSlot slot,
     ffi.Pointer<CBLEncryptable> encryptable,
@@ -3312,20 +2592,6 @@ class cblite {
   late final _FLSlot_SetEncryptableValue = _FLSlot_SetEncryptableValuePtr
       .asFunction<DartFLSlot_SetEncryptableValue>();
 
-  /// Formats and writes a message to the log, in the given domain at the given
-  /// level. \warning This function takes a `printf`-style format string, with
-  /// extra parameters to match the format placeholders, and has the same
-  /// security vulnerabilities as other `printf`-style functions.
-  ///
-  /// If you are logging a fixed string, call \ref CBL_LogMessage instead,
-  /// otherwise any `%` characters in the `format` string will be misinterpreted
-  /// as placeholders and the dreaded Undefined Behavior will result, possibly
-  /// including crashes or overwriting the stack. @param domain The log domain
-  /// to associate this message with. @param level The severity of the message.
-  /// If this is lower than the current minimum level for the domain (as set by
-  /// \ref CBLLog_SetConsoleLevel), nothing is logged. @param format A
-  /// `printf`-style format string. `%` characters in this string introduce
-  /// parameters, and corresponding arguments must follow.
   void CBL_Log(
     int domain,
     int level,
@@ -3342,11 +2608,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeCBL_Log>>('CBL_Log');
   late final _CBL_Log = _CBL_LogPtr.asFunction<DartCBL_Log>();
 
-  /// Writes a pre-formatted message to the log, exactly as given. @param domain
-  /// The log domain to associate this message with. @param level The severity
-  /// of the message. If this is lower than the current minimum level for the
-  /// domain (as set by \ref CBLLog_SetConsoleLevel), nothing is logged. @param
-  /// message The exact message to write to the log.
   void CBL_LogMessage(
     int domain,
     int level,
@@ -3364,8 +2625,6 @@ class cblite {
   late final _CBL_LogMessage =
       _CBL_LogMessagePtr.asFunction<DartCBL_LogMessage>();
 
-  /// Gets the current log level for debug console logging. Only messages at
-  /// this level or higher will be logged to the console.
   int CBLLog_ConsoleLevel() {
     return _CBLLog_ConsoleLevel();
   }
@@ -3376,8 +2635,6 @@ class cblite {
   late final _CBLLog_ConsoleLevel =
       _CBLLog_ConsoleLevelPtr.asFunction<DartCBLLog_ConsoleLevel>();
 
-  /// Sets the detail level of logging. Only messages whose level is ≥ the given
-  /// level will be logged to the console.
   void CBLLog_SetConsoleLevel(
     int arg0,
   ) {
@@ -3392,8 +2649,6 @@ class cblite {
   late final _CBLLog_SetConsoleLevel =
       _CBLLog_SetConsoleLevelPtr.asFunction<DartCBLLog_SetConsoleLevel>();
 
-  /// Gets the current log level for debug console logging. Only messages at
-  /// this level or higher will be logged to the callback.
   int CBLLog_CallbackLevel() {
     return _CBLLog_CallbackLevel();
   }
@@ -3404,8 +2659,6 @@ class cblite {
   late final _CBLLog_CallbackLevel =
       _CBLLog_CallbackLevelPtr.asFunction<DartCBLLog_CallbackLevel>();
 
-  /// Sets the detail level of logging. Only messages whose level is ≥ the given
-  /// level will be logged to the callback.
   void CBLLog_SetCallbackLevel(
     int arg0,
   ) {
@@ -3420,7 +2673,6 @@ class cblite {
   late final _CBLLog_SetCallbackLevel =
       _CBLLog_SetCallbackLevelPtr.asFunction<DartCBLLog_SetCallbackLevel>();
 
-  /// Gets the current log callback.
   CBLLogCallback CBLLog_Callback() {
     return _CBLLog_Callback();
   }
@@ -3430,8 +2682,6 @@ class cblite {
   late final _CBLLog_Callback =
       _CBLLog_CallbackPtr.asFunction<DartCBLLog_Callback>();
 
-  /// Sets the callback for receiving log messages. If set to NULL, no messages
-  /// are logged to the console.
   void CBLLog_SetCallback(
     CBLLogCallback callback,
   ) {
@@ -3446,8 +2696,6 @@ class cblite {
   late final _CBLLog_SetCallback =
       _CBLLog_SetCallbackPtr.asFunction<DartCBLLog_SetCallback>();
 
-  /// Gets the current file logging configuration, or NULL if none is
-  /// configured.
   ffi.Pointer<CBLLogFileConfiguration> CBLLog_FileConfig() {
     return _CBLLog_FileConfig();
   }
@@ -3457,7 +2705,6 @@ class cblite {
   late final _CBLLog_FileConfig =
       _CBLLog_FileConfigPtr.asFunction<DartCBLLog_FileConfig>();
 
-  /// Sets the file logging configuration, and begins logging to files.
   bool CBLLog_SetFileConfig(
     CBLLogFileConfiguration arg0,
     ffi.Pointer<CBLError> outError,
@@ -3474,8 +2721,6 @@ class cblite {
   late final _CBLLog_SetFileConfig =
       _CBLLog_SetFileConfigPtr.asFunction<DartCBLLog_SetFileConfig>();
 
-  /// Registers a predictive model. @param name The name. @param model The
-  /// predictive model.
   void CBL_RegisterPredictiveModel(
     FLString name,
     CBLPredictiveModel model,
@@ -3492,8 +2737,6 @@ class cblite {
   late final _CBL_RegisterPredictiveModel = _CBL_RegisterPredictiveModelPtr
       .asFunction<DartCBL_RegisterPredictiveModel>();
 
-  /// Unregisters the predictive model. @param name The name of the registered
-  /// predictive model.
   void CBL_UnregisterPredictiveModel(
     FLString name,
   ) {
@@ -3508,21 +2751,6 @@ class cblite {
   late final _CBL_UnregisterPredictiveModel = _CBL_UnregisterPredictiveModelPtr
       .asFunction<DartCBL_UnregisterPredictiveModel>();
 
-  /// Creates a new query by compiling the input string. This is fast, but not
-  /// instantaneous. If you need to run the same query many times, keep the \ref
-  /// CBLQuery around instead of compiling it each time. If you need to run
-  /// related queries with only some values different, create one query with
-  /// placeholder parameter(s), and substitute the desired value(s) with \ref
-  /// CBLQuery_SetParameters each time you run the query. @note You must release
-  /// the \ref CBLQuery when you're finished with it. @param db The database to
-  /// query. @param language The query language,
-  /// [JSON](https://github.com/couchbase/couchbase-lite-core/wiki/JSON-Query-Schema)
-  /// or
-  /// [N1QL](https://docs.couchbase.com/server/4.0/n1ql/n1ql-language-reference/index.html).
-  /// @param queryString The query string. @param outErrorPos If non-NULL, then
-  /// on a parse error the approximate byte offset in the input expression will
-  /// be stored here (or -1 if not known/applicable.) @param outError On
-  /// failure, the error will be written here. @return The new query object.
   ffi.Pointer<CBLQuery> CBLDatabase_CreateQuery(
     ffi.Pointer<CBLDatabase> db,
     int language,
@@ -3545,17 +2773,6 @@ class cblite {
   late final _CBLDatabase_CreateQuery =
       _CBLDatabase_CreateQueryPtr.asFunction<DartCBLDatabase_CreateQuery>();
 
-  /// Assigns values to the query's parameters. These values will be substited
-  /// for those parameters whenever the query is executed, until they are next
-  /// assigned.
-  ///
-  /// Parameters are specified in the query source as e.g. `$PARAM` (N1QL) or
-  /// `["$PARAM"]` (JSON). In this example, the `parameters` dictionary to this
-  /// call should have a key `PARAM` that maps to the value of the parameter.
-  /// @param query The query. @param parameters The parameters in the form of a
-  /// Fleece \ref FLDict "dictionary" whose keys are the parameter names. (It's
-  /// easiest to construct this by using the mutable API, i.e. calling \ref
-  /// FLMutableDict_New and adding keys/values.)
   void CBLQuery_SetParameters(
     ffi.Pointer<CBLQuery> query,
     FLDict parameters,
@@ -3572,7 +2789,6 @@ class cblite {
   late final _CBLQuery_SetParameters =
       _CBLQuery_SetParametersPtr.asFunction<DartCBLQuery_SetParameters>();
 
-  /// Returns the query's current parameter bindings, if any.
   FLDict CBLQuery_Parameters(
     ffi.Pointer<CBLQuery> query,
   ) {
@@ -3587,10 +2803,6 @@ class cblite {
   late final _CBLQuery_Parameters =
       _CBLQuery_ParametersPtr.asFunction<DartCBLQuery_Parameters>();
 
-  /// Runs the query, returning the results. To obtain the results you'll
-  /// typically call \ref CBLResultSet_Next in a `while` loop, examining the
-  /// values in the \ref CBLResultSet each time around. @note You must release
-  /// the result set when you're finished with it.
   ffi.Pointer<CBLResultSet> CBLQuery_Execute(
     ffi.Pointer<CBLQuery> arg0,
     ffi.Pointer<CBLError> outError,
@@ -3606,12 +2818,6 @@ class cblite {
   late final _CBLQuery_Execute =
       _CBLQuery_ExecutePtr.asFunction<DartCBLQuery_Execute>();
 
-  /// Returns information about the query, including the translated SQLite form,
-  /// and the search strategy. You can use this to help optimize the query: the
-  /// word `SCAN` in the strategy indicates a linear scan of the entire
-  /// database, which should be avoided by adding an index. The strategy will
-  /// also show which index(es), if any, are used. @note You are responsible for
-  /// releasing the result by calling \ref FLSliceResult_Release.
   FLSliceResult CBLQuery_Explain(
     ffi.Pointer<CBLQuery> arg0,
   ) {
@@ -3625,7 +2831,6 @@ class cblite {
   late final _CBLQuery_Explain =
       _CBLQuery_ExplainPtr.asFunction<DartCBLQuery_Explain>();
 
-  /// Returns the number of columns in each result.
   int CBLQuery_ColumnCount(
     ffi.Pointer<CBLQuery> arg0,
   ) {
@@ -3640,13 +2845,6 @@ class cblite {
   late final _CBLQuery_ColumnCount =
       _CBLQuery_ColumnCountPtr.asFunction<DartCBLQuery_ColumnCount>();
 
-  /// Returns the name of a column in the result. The column name is based on
-  /// its expression in the `SELECT...` or `WHAT:` section of the query. A
-  /// column that returns a property or property path will be named after that
-  /// property. A column that returns an expression will have an
-  /// automatically-generated name like `$1`. To give a column a custom name,
-  /// use the `AS` syntax in the query. Every column is guaranteed to have a
-  /// unique name.
   FLSlice CBLQuery_ColumnName(
     ffi.Pointer<CBLQuery> arg0,
     int columnIndex,
@@ -3663,9 +2861,6 @@ class cblite {
   late final _CBLQuery_ColumnName =
       _CBLQuery_ColumnNamePtr.asFunction<DartCBLQuery_ColumnName>();
 
-  /// Moves the result-set iterator to the next result. Returns false if there
-  /// are no more results. @warning This must be called _before_ examining the
-  /// first result.
   bool CBLResultSet_Next(
     ffi.Pointer<CBLResultSet> arg0,
   ) {
@@ -3679,10 +2874,6 @@ class cblite {
   late final _CBLResultSet_Next =
       _CBLResultSet_NextPtr.asFunction<DartCBLResultSet_Next>();
 
-  /// Returns the value of a column of the current result, given its
-  /// (zero-based) numeric index. This may return a NULL pointer, indicating
-  /// `MISSING`, if the value doesn't exist, e.g. if the column is a property
-  /// that doesn't exist in the document.
   FLValue CBLResultSet_ValueAtIndex(
     ffi.Pointer<CBLResultSet> arg0,
     int index,
@@ -3699,11 +2890,6 @@ class cblite {
   late final _CBLResultSet_ValueAtIndex =
       _CBLResultSet_ValueAtIndexPtr.asFunction<DartCBLResultSet_ValueAtIndex>();
 
-  /// Returns the value of a column of the current result, given its name. This
-  /// may return a NULL pointer, indicating `MISSING`, if the value doesn't
-  /// exist, e.g. if the column is a property that doesn't exist in the
-  /// document. (Or, of course, if the key is not a column name in this query.)
-  /// @note See \ref CBLQuery_ColumnName for a discussion of column names.
   FLValue CBLResultSet_ValueForKey(
     ffi.Pointer<CBLResultSet> arg0,
     FLString key,
@@ -3720,10 +2906,6 @@ class cblite {
   late final _CBLResultSet_ValueForKey =
       _CBLResultSet_ValueForKeyPtr.asFunction<DartCBLResultSet_ValueForKey>();
 
-  /// Returns the current result as an array of column values. @warning The
-  /// array reference is only valid until the result-set is advanced or
-  /// released. If you want to keep it for longer, call \ref FLArray_Retain (and
-  /// release it when done.)
   FLArray CBLResultSet_ResultArray(
     ffi.Pointer<CBLResultSet> arg0,
   ) {
@@ -3738,10 +2920,6 @@ class cblite {
   late final _CBLResultSet_ResultArray =
       _CBLResultSet_ResultArrayPtr.asFunction<DartCBLResultSet_ResultArray>();
 
-  /// Returns the current result as a dictionary mapping column names to values.
-  /// @warning The dict reference is only valid until the result-set is advanced
-  /// or released. If you want to keep it for longer, call \ref FLDict_Retain
-  /// (and release it when done.)
   FLDict CBLResultSet_ResultDict(
     ffi.Pointer<CBLResultSet> arg0,
   ) {
@@ -3756,7 +2934,6 @@ class cblite {
   late final _CBLResultSet_ResultDict =
       _CBLResultSet_ResultDictPtr.asFunction<DartCBLResultSet_ResultDict>();
 
-  /// Returns the Query that created this ResultSet.
   ffi.Pointer<CBLQuery> CBLResultSet_GetQuery(
     ffi.Pointer<CBLResultSet> rs,
   ) {
@@ -3771,16 +2948,6 @@ class cblite {
   late final _CBLResultSet_GetQuery =
       _CBLResultSet_GetQueryPtr.asFunction<DartCBLResultSet_GetQuery>();
 
-  /// Registers a change listener callback with a query, turning it into a "live
-  /// query" until the listener is removed (via \ref CBLListener_Remove).
-  ///
-  /// When the first change listener is added, the query will run (in the
-  /// background) and notify the listener(s) of the results when ready. After
-  /// that, it will run in the background after the database changes, and only
-  /// notify the listeners when the result set changes. @param query The query
-  /// to observe. @param listener The callback to be invoked. @param context An
-  /// opaque value that will be passed to the callback. @return A token to be
-  /// passed to \ref CBLListener_Remove when it's time to remove the listener.
   ffi.Pointer<CBLListenerToken> CBLQuery_AddChangeListener(
     ffi.Pointer<CBLQuery> query,
     CBLQueryChangeListener listener,
@@ -3799,13 +2966,6 @@ class cblite {
   late final _CBLQuery_AddChangeListener = _CBLQuery_AddChangeListenerPtr
       .asFunction<DartCBLQuery_AddChangeListener>();
 
-  /// Returns the query's _entire_ current result set, after it's been announced
-  /// via a call to the listener's callback. @note You must release the result
-  /// set when you're finished with it. @param query The query being listened
-  /// to. @param listener The query listener that was notified. @param outError
-  /// If the query failed to run, the error will be stored here. @return A new
-  /// object containing the query's current results, or NULL if the query failed
-  /// to run.
   ffi.Pointer<CBLResultSet> CBLQuery_CopyCurrentResults(
     ffi.Pointer<CBLQuery> query,
     ffi.Pointer<CBLListenerToken> listener,
@@ -3824,8 +2984,6 @@ class cblite {
   late final _CBLQuery_CopyCurrentResults = _CBLQuery_CopyCurrentResultsPtr
       .asFunction<DartCBLQuery_CopyCurrentResults>();
 
-  /// Returns the index's name. @param index The index. @return The name of the
-  /// index.
   FLString CBLQueryIndex_Name(
     ffi.Pointer<CBLQueryIndex> index,
   ) {
@@ -3840,8 +2998,6 @@ class cblite {
   late final _CBLQueryIndex_Name =
       _CBLQueryIndex_NamePtr.asFunction<DartCBLQueryIndex_Name>();
 
-  /// Returns the collection that the index belongs to. @param index The index.
-  /// @return A \ref CBLCollection instance that the index belongs to.
   ffi.Pointer<CBLCollection> CBLQueryIndex_Collection(
     ffi.Pointer<CBLQueryIndex> index,
   ) {
@@ -3856,17 +3012,6 @@ class cblite {
   late final _CBLQueryIndex_Collection =
       _CBLQueryIndex_CollectionPtr.asFunction<DartCBLQueryIndex_Collection>();
 
-  /// ENTERPRISE EDITION ONLY
-  ///
-  /// Finds new or updated documents for which vectors need to be (re)computed
-  /// and returns an \ref CBLIndexUpdater object for setting the computed
-  /// vectors to update the index. If the index is not lazy, an error will be
-  /// returned. @note For updating lazy vector indexes only. @note You are
-  /// responsible for releasing the returned A \ref CBLIndexUpdater object.
-  /// @param index The index. @param limit The maximum number of vectors to be
-  /// computed. @param outError On failure, an error is written here. @return A
-  /// \ref CBLIndexUpdater object for setting the computed vectors to update the
-  /// index, or NULL if the index is up-to-date or an error occurred.
   ffi.Pointer<CBLIndexUpdater> CBLQueryIndex_BeginUpdate(
     ffi.Pointer<CBLQueryIndex> index,
     int limit,
@@ -3885,11 +3030,6 @@ class cblite {
   late final _CBLQueryIndex_BeginUpdate =
       _CBLQueryIndex_BeginUpdatePtr.asFunction<DartCBLQueryIndex_BeginUpdate>();
 
-  /// ENTERPRISE EDITION ONLY
-  ///
-  /// Returns the total number of vectors to compute and set for updating the
-  /// index. @param updater The index updater. @return The total number of
-  /// vectors to compute and set for updating the index.
   int CBLIndexUpdater_Count(
     ffi.Pointer<CBLIndexUpdater> updater,
   ) {
@@ -3904,13 +3044,6 @@ class cblite {
   late final _CBLIndexUpdater_Count =
       _CBLIndexUpdater_CountPtr.asFunction<DartCBLIndexUpdater_Count>();
 
-  /// ENTERPRISE EDITION ONLY
-  ///
-  /// Returns the valut at the given index to compute a vector from. @note The
-  /// returned Fleece value is valid unilt its \ref CBLIndexUpdater is released.
-  /// If you want to keep it longer, retain it with `FLRetain`. @param updater
-  /// The index updater. @param index The zero-based index. @return A Fleece
-  /// value of the index's evaluated expression at the given index.
   FLValue CBLIndexUpdater_Value(
     ffi.Pointer<CBLIndexUpdater> updater,
     int index,
@@ -3927,17 +3060,6 @@ class cblite {
   late final _CBLIndexUpdater_Value =
       _CBLIndexUpdater_ValuePtr.asFunction<DartCBLIndexUpdater_Value>();
 
-  /// ENTERPRISE EDITION ONLY
-  ///
-  /// Sets the vector for the value corresponding to the given index. Setting
-  /// null vector means that there is no vector for the value, and any existing
-  /// vector will be removed when the `CBLIndexUpdater_Finish` is called. @param
-  /// updater The index updater. @param index The zero-based index. @param
-  /// vector A pointer to the vector which is an array of floats, or NULL if
-  /// there is no vector. @param dimension The dimension of `vector`. Must be
-  /// equal to the dimension value set in the vector index config. @param
-  /// outError On failure, an error is written here. @return True if success, or
-  /// False if an error occurred.
   bool CBLIndexUpdater_SetVector(
     ffi.Pointer<CBLIndexUpdater> updater,
     int index,
@@ -3960,12 +3082,6 @@ class cblite {
   late final _CBLIndexUpdater_SetVector =
       _CBLIndexUpdater_SetVectorPtr.asFunction<DartCBLIndexUpdater_SetVector>();
 
-  /// ENTERPRISE EDITION ONLY
-  ///
-  /// Skip setting the vector for the value corresponding to the index. The
-  /// vector will be required to compute and set again when the
-  /// `CBLQueryIndex_BeginUpdate` is later called. @param updater The index
-  /// updater. @param index The zero-based index.
   void CBLIndexUpdater_SkipVector(
     ffi.Pointer<CBLIndexUpdater> updater,
     int index,
@@ -3982,16 +3098,6 @@ class cblite {
   late final _CBLIndexUpdater_SkipVector = _CBLIndexUpdater_SkipVectorPtr
       .asFunction<DartCBLIndexUpdater_SkipVector>();
 
-  /// ENTERPRISE EDITION ONLY
-  ///
-  /// Updates the index with the computed vectors and removes any index rows for
-  /// which null vector was given. If there are any indexes that do not have
-  /// their vector value set or are skipped, a error will be returned. @note
-  /// Before calling `CBLIndexUpdater_Finish`, the set vectors are kept in the
-  /// memory. @warning The index updater cannot be used after calling
-  /// `CBLIndexUpdater_Finish`. @param updater The index updater. @param
-  /// outError On failure, an error is written here. @return True if success, or
-  /// False if an error occurred.
   bool CBLIndexUpdater_Finish(
     ffi.Pointer<CBLIndexUpdater> updater,
     ffi.Pointer<CBLError> outError,
@@ -4008,14 +3114,11 @@ class cblite {
   late final _CBLIndexUpdater_Finish =
       _CBLIndexUpdater_FinishPtr.asFunction<DartCBLIndexUpdater_Finish>();
 
-  /// The default scope's name.
   late final ffi.Pointer<FLString> _kCBLDefaultScopeName =
       _lookup<FLString>('kCBLDefaultScopeName');
 
   FLString get kCBLDefaultScopeName => _kCBLDefaultScopeName.ref;
 
-  /// Returns the name of the scope. @param scope The scope. @return The name of
-  /// the scope.
   FLString CBLScope_Name(
     ffi.Pointer<CBLScope> scope,
   ) {
@@ -4028,9 +3131,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeCBLScope_Name>>('CBLScope_Name');
   late final _CBLScope_Name = _CBLScope_NamePtr.asFunction<DartCBLScope_Name>();
 
-  /// Returns the scope's database. @note The database object is owned by the
-  /// scope object; you do not need to release it. @param scope The scope.
-  /// @return The database of the scope.
   ffi.Pointer<CBLDatabase> CBLScope_Database(
     ffi.Pointer<CBLScope> scope,
   ) {
@@ -4044,10 +3144,6 @@ class cblite {
   late final _CBLScope_Database =
       _CBLScope_DatabasePtr.asFunction<DartCBLScope_Database>();
 
-  /// Returns the names of all collections in the scope. @note You are
-  /// responsible for releasing the returned array. @param scope The scope.
-  /// @param outError On failure, the error will be written here. @return The
-  /// names of all collections in the scope, or NULL if an error occurred.
   FLMutableArray CBLScope_CollectionNames(
     ffi.Pointer<CBLScope> scope,
     ffi.Pointer<CBLError> outError,
@@ -4064,11 +3160,6 @@ class cblite {
   late final _CBLScope_CollectionNames =
       _CBLScope_CollectionNamesPtr.asFunction<DartCBLScope_CollectionNames>();
 
-  /// Returns an existing collection in the scope with the given name. @note You
-  /// are responsible for releasing the returned collection. @param scope The
-  /// scope. @param collectionName The name of the collection. @param outError
-  /// On failure, the error will be written here. @return A \ref CBLCollection
-  /// instance, or NULL if the collection doesn't exist or an error occurred.
   ffi.Pointer<CBLCollection> CBLScope_Collection(
     ffi.Pointer<CBLScope> scope,
     FLString collectionName,
@@ -4087,7 +3178,6 @@ class cblite {
   late final _CBLScope_Collection =
       _CBLScope_CollectionPtr.asFunction<DartCBLScope_Collection>();
 
-  /// Equality test of two slices.
   bool FLSlice_Equal(
     FLSlice a,
     FLSlice b,
@@ -4102,8 +3192,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLSlice_Equal>>('FLSlice_Equal');
   late final _FLSlice_Equal = _FLSlice_EqualPtr.asFunction<DartFLSlice_Equal>();
 
-  /// Lexicographic comparison of two slices; basically like memcmp(), but
-  /// taking into account differences in length.
   int FLSlice_Compare(
     FLSlice arg0,
     FLSlice arg1,
@@ -4119,7 +3207,6 @@ class cblite {
   late final _FLSlice_Compare =
       _FLSlice_ComparePtr.asFunction<DartFLSlice_Compare>();
 
-  /// Computes a 32-bit hash of a slice's data, suitable for use in hash tables.
   int FLSlice_Hash(
     FLSlice s,
   ) {
@@ -4132,13 +3219,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLSlice_Hash>>('FLSlice_Hash');
   late final _FLSlice_Hash = _FLSlice_HashPtr.asFunction<DartFLSlice_Hash>();
 
-  /// Copies a slice to a buffer, adding a trailing zero byte to make it a valid
-  /// C string. If there is not enough capacity the slice will be truncated, but
-  /// the trailing zero byte is always written. @param s The FLSlice to copy.
-  /// @param buffer Where to copy the bytes. At least `capacity` bytes must be
-  /// available. @param capacity The maximum number of bytes to copy (including
-  /// the trailing 0.) @return True if the entire slice was copied, false if it
-  /// was truncated.
   bool FLSlice_ToCString(
     FLSlice s,
     ffi.Pointer<ffi.Char> buffer,
@@ -4156,8 +3236,6 @@ class cblite {
   late final _FLSlice_ToCString =
       _FLSlice_ToCStringPtr.asFunction<DartFLSlice_ToCString>();
 
-  /// Allocates an FLSliceResult of the given size, without initializing the
-  /// buffer.
   FLSliceResult FLSliceResult_New(
     int arg0,
   ) {
@@ -4171,7 +3249,6 @@ class cblite {
   late final _FLSliceResult_New =
       _FLSliceResult_NewPtr.asFunction<DartFLSliceResult_New>();
 
-  /// Allocates an FLSliceResult, copying the given slice.
   FLSliceResult FLSlice_Copy(
     FLSlice arg0,
   ) {
@@ -4208,9 +3285,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLBuf_Release>>('_FLBuf_Release');
   late final _FLBuf_Release = _FLBuf_ReleasePtr.asFunction<DartFLBuf_Release>();
 
-  /// Writes zeroes to `size` bytes of memory starting at `dst`. Unlike a call
-  /// to `memset`, these writes cannot be optimized away by the compiler. This
-  /// is useful for securely removing traces of passwords or encryption keys.
   void FL_WipeMemory(
     ffi.Pointer<ffi.Void> dst,
     int size,
@@ -4225,7 +3299,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFL_WipeMemory>>('FL_WipeMemory');
   late final _FL_WipeMemory = _FL_WipeMemoryPtr.asFunction<DartFL_WipeMemory>();
 
-  /// Returns an FLTimestamp corresponding to the current time.
   int FLTimestamp_Now() {
     return _FLTimestamp_Now();
   }
@@ -4235,12 +3308,6 @@ class cblite {
   late final _FLTimestamp_Now =
       _FLTimestamp_NowPtr.asFunction<DartFLTimestamp_Now>();
 
-  /// Formats a timestamp as a date-time string in ISO-8601 format. @note See
-  /// also \ref FLEncoder_WriteDateString, which writes a timestamp to an
-  /// `FLEncoder`. @param timestamp A time, given as milliseconds since the Unix
-  /// epoch (1/1/1970 00:00 UTC.) @param asUTC If true, the timestamp will be
-  /// given in universal time; if false, in the local timezone. @return A
-  /// heap-allocated string, which you are responsible for releasing.
   FLStringResult FLTimestamp_ToString(
     int timestamp,
     bool asUTC,
@@ -4257,9 +3324,6 @@ class cblite {
   late final _FLTimestamp_ToString =
       _FLTimestamp_ToStringPtr.asFunction<DartFLTimestamp_ToString>();
 
-  /// Parses an ISO-8601 date-time string to a timestamp. On failure returns
-  /// `FLTimestampNone`. @note See also \ref FLValue_AsTimestamp, which takes an
-  /// `FLValue` and interprets numeric representations as well as strings.
   int FLTimestamp_FromString(
     FLString str,
   ) {
@@ -4274,7 +3338,6 @@ class cblite {
   late final _FLTimestamp_FromString =
       _FLTimestamp_FromStringPtr.asFunction<DartFLTimestamp_FromString>();
 
-  /// A constant empty array value.
   late final ffi.Pointer<FLArray> _kFLEmptyArray =
       _lookup<FLArray>('kFLEmptyArray');
 
@@ -4282,7 +3345,6 @@ class cblite {
 
   set kFLEmptyArray(FLArray value) => _kFLEmptyArray.value = value;
 
-  /// Returns the number of items in an array, or 0 if the pointer is NULL.
   int FLArray_Count(
     FLArray arg0,
   ) {
@@ -4295,8 +3357,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLArray_Count>>('FLArray_Count');
   late final _FLArray_Count = _FLArray_CountPtr.asFunction<DartFLArray_Count>();
 
-  /// Returns true if an array is empty (or NULL). Depending on the array's
-  /// representation, this can be faster than `FLArray_Count(a) == 0`
   bool FLArray_IsEmpty(
     FLArray arg0,
   ) {
@@ -4310,7 +3370,6 @@ class cblite {
   late final _FLArray_IsEmpty =
       _FLArray_IsEmptyPtr.asFunction<DartFLArray_IsEmpty>();
 
-  /// If the array is mutable, returns it cast to FLMutableArray, else NULL.
   FLMutableArray FLArray_AsMutable(
     FLArray arg0,
   ) {
@@ -4324,7 +3383,6 @@ class cblite {
   late final _FLArray_AsMutable =
       _FLArray_AsMutablePtr.asFunction<DartFLArray_AsMutable>();
 
-  /// Returns an value at an array index, or NULL if the index is out of range.
   FLValue FLArray_Get(
     FLArray arg0,
     int index,
@@ -4339,9 +3397,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLArray_Get>>('FLArray_Get');
   late final _FLArray_Get = _FLArray_GetPtr.asFunction<DartFLArray_Get>();
 
-  /// Initializes a FLArrayIterator struct to iterate over an array. Call
-  /// FLArrayIteratorGetValue to get the first item, then as long as the item is
-  /// not NULL, call FLArrayIterator_Next to advance.
   void FLArrayIterator_Begin(
     FLArray arg0,
     ffi.Pointer<FLArrayIterator> arg1,
@@ -4358,7 +3413,6 @@ class cblite {
   late final _FLArrayIterator_Begin =
       _FLArrayIterator_BeginPtr.asFunction<DartFLArrayIterator_Begin>();
 
-  /// Returns the current value being iterated over, or NULL at the end.
   FLValue FLArrayIterator_GetValue(
     ffi.Pointer<FLArrayIterator> arg0,
   ) {
@@ -4373,7 +3427,6 @@ class cblite {
   late final _FLArrayIterator_GetValue =
       _FLArrayIterator_GetValuePtr.asFunction<DartFLArrayIterator_GetValue>();
 
-  /// Returns a value in the array at the given offset from the current value.
   FLValue FLArrayIterator_GetValueAt(
     ffi.Pointer<FLArrayIterator> arg0,
     int offset,
@@ -4390,8 +3443,6 @@ class cblite {
   late final _FLArrayIterator_GetValueAt = _FLArrayIterator_GetValueAtPtr
       .asFunction<DartFLArrayIterator_GetValueAt>();
 
-  /// Returns the number of items remaining to be iterated, including the
-  /// current one.
   int FLArrayIterator_GetCount(
     ffi.Pointer<FLArrayIterator> arg0,
   ) {
@@ -4406,9 +3457,6 @@ class cblite {
   late final _FLArrayIterator_GetCount =
       _FLArrayIterator_GetCountPtr.asFunction<DartFLArrayIterator_GetCount>();
 
-  /// Advances the iterator to the next value. @warning It is illegal to call
-  /// this when the iterator is already at the end. In particular, calling this
-  /// when the array is empty is always illegal.
   bool FLArrayIterator_Next(
     ffi.Pointer<FLArrayIterator> arg0,
   ) {
@@ -4423,7 +3471,6 @@ class cblite {
   late final _FLArrayIterator_Next =
       _FLArrayIterator_NextPtr.asFunction<DartFLArrayIterator_Next>();
 
-  /// A constant empty array value.
   late final ffi.Pointer<FLDict> _kFLEmptyDict =
       _lookup<FLDict>('kFLEmptyDict');
 
@@ -4431,7 +3478,6 @@ class cblite {
 
   set kFLEmptyDict(FLDict value) => _kFLEmptyDict.value = value;
 
-  /// Returns the number of items in a dictionary, or 0 if the pointer is NULL.
   int FLDict_Count(
     FLDict arg0,
   ) {
@@ -4444,9 +3490,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLDict_Count>>('FLDict_Count');
   late final _FLDict_Count = _FLDict_CountPtr.asFunction<DartFLDict_Count>();
 
-  /// Returns true if a dictionary is empty (or NULL). Depending on the
-  /// dictionary's representation, this can be faster than
-  /// `FLDict_Count(a) == 0`
   bool FLDict_IsEmpty(
     FLDict arg0,
   ) {
@@ -4460,7 +3503,6 @@ class cblite {
   late final _FLDict_IsEmpty =
       _FLDict_IsEmptyPtr.asFunction<DartFLDict_IsEmpty>();
 
-  /// If the dictionary is mutable, returns it cast to FLMutableDict, else NULL.
   FLMutableDict FLDict_AsMutable(
     FLDict arg0,
   ) {
@@ -4474,8 +3516,6 @@ class cblite {
   late final _FLDict_AsMutable =
       _FLDict_AsMutablePtr.asFunction<DartFLDict_AsMutable>();
 
-  /// Looks up a key in a dictionary, returning its value. Returns NULL if the
-  /// value is not found or if the dictionary is NULL.
   FLValue FLDict_Get(
     FLDict arg0,
     FLSlice keyString,
@@ -4490,9 +3530,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLDict_Get>>('FLDict_Get');
   late final _FLDict_Get = _FLDict_GetPtr.asFunction<DartFLDict_Get>();
 
-  /// Initializes a FLDictIterator struct to iterate over a dictionary. Call
-  /// FLDictIterator_GetKey and FLDictIterator_GetValue to get the first item,
-  /// then as long as the item is not NULL, call FLDictIterator_Next to advance.
   void FLDictIterator_Begin(
     FLDict arg0,
     ffi.Pointer<FLDictIterator> arg1,
@@ -4509,8 +3546,6 @@ class cblite {
   late final _FLDictIterator_Begin =
       _FLDictIterator_BeginPtr.asFunction<DartFLDictIterator_Begin>();
 
-  /// Returns the current key being iterated over. This Value will be a string
-  /// or an integer, or NULL when there are no more keys.
   FLValue FLDictIterator_GetKey(
     ffi.Pointer<FLDictIterator> arg0,
   ) {
@@ -4525,8 +3560,6 @@ class cblite {
   late final _FLDictIterator_GetKey =
       _FLDictIterator_GetKeyPtr.asFunction<DartFLDictIterator_GetKey>();
 
-  /// Returns the current key's string value, or NULL when there are no more
-  /// keys.
   FLString FLDictIterator_GetKeyString(
     ffi.Pointer<FLDictIterator> arg0,
   ) {
@@ -4541,8 +3574,6 @@ class cblite {
   late final _FLDictIterator_GetKeyString = _FLDictIterator_GetKeyStringPtr
       .asFunction<DartFLDictIterator_GetKeyString>();
 
-  /// Returns the current value being iterated over. Returns NULL when there are
-  /// no more values.
   FLValue FLDictIterator_GetValue(
     ffi.Pointer<FLDictIterator> arg0,
   ) {
@@ -4557,8 +3588,6 @@ class cblite {
   late final _FLDictIterator_GetValue =
       _FLDictIterator_GetValuePtr.asFunction<DartFLDictIterator_GetValue>();
 
-  /// Returns the number of items remaining to be iterated, including the
-  /// current one.
   int FLDictIterator_GetCount(
     ffi.Pointer<FLDictIterator> arg0,
   ) {
@@ -4573,9 +3602,6 @@ class cblite {
   late final _FLDictIterator_GetCount =
       _FLDictIterator_GetCountPtr.asFunction<DartFLDictIterator_GetCount>();
 
-  /// Advances the iterator to the next value. @warning It is illegal to call
-  /// this when the iterator is already at the end. In particular, calling this
-  /// when the dict is empty is always illegal.
   bool FLDictIterator_Next(
     ffi.Pointer<FLDictIterator> arg0,
   ) {
@@ -4590,9 +3616,6 @@ class cblite {
   late final _FLDictIterator_Next =
       _FLDictIterator_NextPtr.asFunction<DartFLDictIterator_Next>();
 
-  /// Cleans up after an iterator. Only needed if (a) the dictionary is a delta,
-  /// and (b) you stop iterating before the end (i.e. before FLDictIterator_Next
-  /// returns false.)
   void FLDictIterator_End(
     ffi.Pointer<FLDictIterator> arg0,
   ) {
@@ -4607,11 +3630,6 @@ class cblite {
   late final _FLDictIterator_End =
       _FLDictIterator_EndPtr.asFunction<DartFLDictIterator_End>();
 
-  /// Initializes an FLDictKey struct with a key string. @warning The input
-  /// string's memory MUST remain valid for as long as the FLDictKey is in use!
-  /// (The FLDictKey stores a pointer to the string, but does not copy it.)
-  /// @param string The key string (UTF-8). @return An initialized FLDictKey
-  /// struct.
   FLDictKey FLDictKey_Init(
     FLSlice string,
   ) {
@@ -4625,7 +3643,6 @@ class cblite {
   late final _FLDictKey_Init =
       _FLDictKey_InitPtr.asFunction<DartFLDictKey_Init>();
 
-  /// Returns the string value of the key (which it was initialized with.)
   FLString FLDictKey_GetString(
     ffi.Pointer<FLDictKey> arg0,
   ) {
@@ -4640,9 +3657,6 @@ class cblite {
   late final _FLDictKey_GetString =
       _FLDictKey_GetStringPtr.asFunction<DartFLDictKey_GetString>();
 
-  /// Looks up a key in a dictionary using an FLDictKey. If the key is found,
-  /// "hint" data will be stored inside the FLDictKey that will speed up
-  /// subsequent lookups.
   FLValue FLDict_GetWithKey(
     FLDict arg0,
     ffi.Pointer<FLDictKey> arg1,
@@ -4658,9 +3672,6 @@ class cblite {
   late final _FLDict_GetWithKey =
       _FLDict_GetWithKeyPtr.asFunction<DartFLDict_GetWithKey>();
 
-  /// Creates a FLDeepIterator to iterate over a dictionary. Call
-  /// FLDeepIterator_GetKey and FLDeepIterator_GetValue to get the first item,
-  /// then FLDeepIterator_Next.
   FLDeepIterator FLDeepIterator_New(
     FLValue arg0,
   ) {
@@ -4689,8 +3700,6 @@ class cblite {
   late final _FLDeepIterator_Free =
       _FLDeepIterator_FreePtr.asFunction<DartFLDeepIterator_Free>();
 
-  /// Returns the current value being iterated over. or NULL at the end of
-  /// iteration.
   FLValue FLDeepIterator_GetValue(
     FLDeepIterator arg0,
   ) {
@@ -4705,8 +3714,6 @@ class cblite {
   late final _FLDeepIterator_GetValue =
       _FLDeepIterator_GetValuePtr.asFunction<DartFLDeepIterator_GetValue>();
 
-  /// Returns the parent/container of the current value, or NULL at the end of
-  /// iteration.
   FLValue FLDeepIterator_GetParent(
     FLDeepIterator arg0,
   ) {
@@ -4721,8 +3728,6 @@ class cblite {
   late final _FLDeepIterator_GetParent =
       _FLDeepIterator_GetParentPtr.asFunction<DartFLDeepIterator_GetParent>();
 
-  /// Returns the key of the current value in its parent, or an empty slice if
-  /// not in a dictionary.
   FLSlice FLDeepIterator_GetKey(
     FLDeepIterator arg0,
   ) {
@@ -4737,8 +3742,6 @@ class cblite {
   late final _FLDeepIterator_GetKey =
       _FLDeepIterator_GetKeyPtr.asFunction<DartFLDeepIterator_GetKey>();
 
-  /// Returns the array index of the current value in its parent, or 0 if not in
-  /// an array.
   int FLDeepIterator_GetIndex(
     FLDeepIterator arg0,
   ) {
@@ -4753,8 +3756,6 @@ class cblite {
   late final _FLDeepIterator_GetIndex =
       _FLDeepIterator_GetIndexPtr.asFunction<DartFLDeepIterator_GetIndex>();
 
-  /// Returns the current depth in the hierarchy, starting at 1 for the
-  /// top-level children.
   int FLDeepIterator_GetDepth(
     FLDeepIterator arg0,
   ) {
@@ -4769,7 +3770,6 @@ class cblite {
   late final _FLDeepIterator_GetDepth =
       _FLDeepIterator_GetDepthPtr.asFunction<DartFLDeepIterator_GetDepth>();
 
-  /// Tells the iterator to skip the children of the current value.
   void FLDeepIterator_SkipChildren(
     FLDeepIterator arg0,
   ) {
@@ -4784,7 +3784,6 @@ class cblite {
   late final _FLDeepIterator_SkipChildren = _FLDeepIterator_SkipChildrenPtr
       .asFunction<DartFLDeepIterator_SkipChildren>();
 
-  /// Advances the iterator to the next value, or returns false if at the end.
   bool FLDeepIterator_Next(
     FLDeepIterator arg0,
   ) {
@@ -4799,7 +3798,6 @@ class cblite {
   late final _FLDeepIterator_Next =
       _FLDeepIterator_NextPtr.asFunction<DartFLDeepIterator_Next>();
 
-  /// Returns the path as an array of FLPathComponents.
   void FLDeepIterator_GetPath(
     FLDeepIterator arg0,
     ffi.Pointer<ffi.Pointer<FLPathComponent>> outPath,
@@ -4818,7 +3816,6 @@ class cblite {
   late final _FLDeepIterator_GetPath =
       _FLDeepIterator_GetPathPtr.asFunction<DartFLDeepIterator_GetPath>();
 
-  /// Returns the current path in JavaScript format.
   FLSliceResult FLDeepIterator_GetPathString(
     FLDeepIterator arg0,
   ) {
@@ -4833,7 +3830,6 @@ class cblite {
   late final _FLDeepIterator_GetPathString = _FLDeepIterator_GetPathStringPtr
       .asFunction<DartFLDeepIterator_GetPathString>();
 
-  /// Returns the current path in JSONPointer format (RFC 6901).
   FLSliceResult FLDeepIterator_GetJSONPointer(
     FLDeepIterator arg0,
   ) {
@@ -4848,9 +3844,6 @@ class cblite {
   late final _FLDeepIterator_GetJSONPointer = _FLDeepIterator_GetJSONPointerPtr
       .asFunction<DartFLDeepIterator_GetJSONPointer>();
 
-  /// Creates an FLDoc from Fleece-encoded data that's been returned as a result
-  /// from FLSlice_Copy or other API. The resulting document retains the data,
-  /// so you don't need to worry about it remaining valid.
   FLDoc FLDoc_FromResultData(
     FLSliceResult data,
     FLTrust arg1,
@@ -4871,8 +3864,6 @@ class cblite {
   late final _FLDoc_FromResultData =
       _FLDoc_FromResultDataPtr.asFunction<DartFLDoc_FromResultData>();
 
-  /// Releases a reference to an FLDoc. This must be called once to free an
-  /// FLDoc you created.
   void FLDoc_Release(
     FLDoc arg0,
   ) {
@@ -4885,8 +3876,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLDoc_Release>>('FLDoc_Release');
   late final _FLDoc_Release = _FLDoc_ReleasePtr.asFunction<DartFLDoc_Release>();
 
-  /// Adds a reference to an FLDoc. This extends its lifespan until at least
-  /// such time as you call FLRelease to remove the reference.
   FLDoc FLDoc_Retain(
     FLDoc arg0,
   ) {
@@ -4899,7 +3888,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLDoc_Retain>>('FLDoc_Retain');
   late final _FLDoc_Retain = _FLDoc_RetainPtr.asFunction<DartFLDoc_Retain>();
 
-  /// Returns the encoded Fleece data backing the document.
   FLSlice FLDoc_GetData(
     FLDoc arg0,
   ) {
@@ -4912,8 +3900,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLDoc_GetData>>('FLDoc_GetData');
   late final _FLDoc_GetData = _FLDoc_GetDataPtr.asFunction<DartFLDoc_GetData>();
 
-  /// Returns the FLSliceResult data owned by the document, if any, else a null
-  /// slice.
   FLSliceResult FLDoc_GetAllocedData(
     FLDoc arg0,
   ) {
@@ -4928,7 +3914,6 @@ class cblite {
   late final _FLDoc_GetAllocedData =
       _FLDoc_GetAllocedDataPtr.asFunction<DartFLDoc_GetAllocedData>();
 
-  /// Returns the root value in the FLDoc, usually an FLDict.
   FLValue FLDoc_GetRoot(
     FLDoc arg0,
   ) {
@@ -4941,8 +3926,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLDoc_GetRoot>>('FLDoc_GetRoot');
   late final _FLDoc_GetRoot = _FLDoc_GetRootPtr.asFunction<DartFLDoc_GetRoot>();
 
-  /// Returns the FLSharedKeys used by this FLDoc, as specified when it was
-  /// created.
   FLSharedKeys FLDoc_GetSharedKeys(
     FLDoc arg0,
   ) {
@@ -4957,8 +3940,6 @@ class cblite {
   late final _FLDoc_GetSharedKeys =
       _FLDoc_GetSharedKeysPtr.asFunction<DartFLDoc_GetSharedKeys>();
 
-  /// Looks up the Doc containing the Value, or NULL if there is none. @note
-  /// Caller must release the FLDoc reference!!
   FLDoc FLValue_FindDoc(
     FLValue arg0,
   ) {
@@ -4972,20 +3953,6 @@ class cblite {
   late final _FLValue_FindDoc =
       _FLValue_FindDocPtr.asFunction<DartFLValue_FindDoc>();
 
-  /// Associates an arbitrary pointer value with a document, and thus its
-  /// contained values. Allows client code to associate its own pointer with
-  /// this FLDoc and its Values, which can later be retrieved with \ref
-  /// FLDoc_GetAssociated. For example, this could be a pointer to an
-  /// `app::Document` object, of which this Doc's root FLDict is its properties.
-  /// You would store it by calling
-  /// `FLDoc_SetAssociated(doc, myDoc, "app::Document");`. @param doc The FLDoc
-  /// to store a pointer in. @param pointer The pointer to store in the FLDoc.
-  /// @param type A C string literal identifying the type. This is used to avoid
-  /// collisions with unrelated code that might try to store a different type of
-  /// value. @return True if the pointer was stored, false if a pointer of a
-  /// different type is already stored. @warning Be sure to clear this before
-  /// the associated object is freed/invalidated! @warning This function is not
-  /// thread-safe. Do not concurrently get & set objects.
   bool FLDoc_SetAssociated(
     FLDoc doc,
     ffi.Pointer<ffi.Void> pointer,
@@ -5004,13 +3971,6 @@ class cblite {
   late final _FLDoc_SetAssociated =
       _FLDoc_SetAssociatedPtr.asFunction<DartFLDoc_SetAssociated>();
 
-  /// Returns the pointer associated with the document. You can use this
-  /// together with \ref FLValue_FindDoc to associate your own object with
-  /// Fleece values, for instance to find your object that "owns" a value:
-  /// `myDoc = (app::Document*)FLDoc_GetAssociated(FLValue_FindDoc(val), "app::Document");`.
-  /// @param doc The FLDoc to get a pointer from. @param type The type of object
-  /// expected, i.e. the same string literal passed to \ref FLDoc_SetAssociated.
-  /// @return The associated pointer of that type, if any.
   ffi.Pointer<ffi.Void> FLDoc_GetAssociated(
     FLDoc doc,
     ffi.Pointer<ffi.Char> type,
@@ -5027,8 +3987,6 @@ class cblite {
   late final _FLDoc_GetAssociated =
       _FLDoc_GetAssociatedPtr.asFunction<DartFLDoc_GetAssociated>();
 
-  /// Creates a new encoder, for generating Fleece data. Call FLEncoder_Free
-  /// when done.
   FLEncoder FLEncoder_New() {
     return _FLEncoder_New();
   }
@@ -5037,14 +3995,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLEncoder_New>>('FLEncoder_New');
   late final _FLEncoder_New = _FLEncoder_NewPtr.asFunction<DartFLEncoder_New>();
 
-  /// Creates a new encoder, allowing some options to be customized. @param
-  /// format The output format to generate (Fleece, JSON, or JSON5.) @param
-  /// reserveSize The number of bytes to preallocate for the output. (Default
-  /// is 256) @param uniqueStrings (Fleece only) If true, string values that
-  /// appear multiple times will be written as a single shared value. This saves
-  /// space but makes encoding slightly slower. You should only turn this off if
-  /// you know you're going to be writing large numbers of non-repeated strings.
-  /// (Default is true)
   FLEncoder FLEncoder_NewWithOptions(
     FLEncoderFormat format,
     int reserveSize,
@@ -5063,7 +4013,6 @@ class cblite {
   late final _FLEncoder_NewWithOptions =
       _FLEncoder_NewWithOptionsPtr.asFunction<DartFLEncoder_NewWithOptions>();
 
-  /// Creates a new Fleece encoder that writes to a file, not to memory.
   FLEncoder FLEncoder_NewWritingToFile(
     ffi.Pointer<FILE> arg0,
     bool uniqueStrings,
@@ -5080,7 +4029,6 @@ class cblite {
   late final _FLEncoder_NewWritingToFile = _FLEncoder_NewWritingToFilePtr
       .asFunction<DartFLEncoder_NewWritingToFile>();
 
-  /// Frees the space used by an encoder.
   void FLEncoder_Free(
     FLEncoder arg0,
   ) {
@@ -5094,8 +4042,6 @@ class cblite {
   late final _FLEncoder_Free =
       _FLEncoder_FreePtr.asFunction<DartFLEncoder_Free>();
 
-  /// Tells the encoder to use a shared-keys mapping when encoding dictionary
-  /// keys.
   void FLEncoder_SetSharedKeys(
     FLEncoder arg0,
     FLSharedKeys arg1,
@@ -5112,7 +4058,6 @@ class cblite {
   late final _FLEncoder_SetSharedKeys =
       _FLEncoder_SetSharedKeysPtr.asFunction<DartFLEncoder_SetSharedKeys>();
 
-  /// Associates an arbitrary user-defined value with the encoder.
   void FLEncoder_SetExtraInfo(
     FLEncoder arg0,
     ffi.Pointer<ffi.Void> info,
@@ -5129,8 +4074,6 @@ class cblite {
   late final _FLEncoder_SetExtraInfo =
       _FLEncoder_SetExtraInfoPtr.asFunction<DartFLEncoder_SetExtraInfo>();
 
-  /// Returns the user-defined value associated with the encoder; NULL by
-  /// default.
   ffi.Pointer<ffi.Void> FLEncoder_GetExtraInfo(
     FLEncoder arg0,
   ) {
@@ -5145,8 +4088,6 @@ class cblite {
   late final _FLEncoder_GetExtraInfo =
       _FLEncoder_GetExtraInfoPtr.asFunction<DartFLEncoder_GetExtraInfo>();
 
-  /// Resets the state of an encoder without freeing it. It can then be reused
-  /// to encode another value.
   void FLEncoder_Reset(
     FLEncoder arg0,
   ) {
@@ -5160,7 +4101,6 @@ class cblite {
   late final _FLEncoder_Reset =
       _FLEncoder_ResetPtr.asFunction<DartFLEncoder_Reset>();
 
-  /// Returns the number of bytes encoded so far.
   int FLEncoder_BytesWritten(
     FLEncoder arg0,
   ) {
@@ -5175,9 +4115,6 @@ class cblite {
   late final _FLEncoder_BytesWritten =
       _FLEncoder_BytesWrittenPtr.asFunction<DartFLEncoder_BytesWritten>();
 
-  /// Writes a `null` value to an encoder. (This is an explicitly-stored null,
-  /// like the JSON `null`, not the "undefined" value represented by a NULL
-  /// FLValue pointer.)
   bool FLEncoder_WriteNull(
     FLEncoder arg0,
   ) {
@@ -5192,11 +4129,6 @@ class cblite {
   late final _FLEncoder_WriteNull =
       _FLEncoder_WriteNullPtr.asFunction<DartFLEncoder_WriteNull>();
 
-  /// Writes an `undefined` value to an encoder. (Its value when read will not
-  /// be a `NULL` pointer, but it can be recognized by `FLValue_GetType`
-  /// returning `kFLUndefined`.) @note The only real use for writing undefined
-  /// values is to represent "holes" in an array. An undefined dictionary value
-  /// should be written simply by skipping the key and value.
   bool FLEncoder_WriteUndefined(
     FLEncoder arg0,
   ) {
@@ -5211,7 +4143,6 @@ class cblite {
   late final _FLEncoder_WriteUndefined =
       _FLEncoder_WriteUndefinedPtr.asFunction<DartFLEncoder_WriteUndefined>();
 
-  /// Writes a boolean value (true or false) to an encoder.
   bool FLEncoder_WriteBool(
     FLEncoder arg0,
     bool arg1,
@@ -5228,10 +4159,6 @@ class cblite {
   late final _FLEncoder_WriteBool =
       _FLEncoder_WriteBoolPtr.asFunction<DartFLEncoder_WriteBool>();
 
-  /// Writes an integer to an encoder. The parameter is typed as `int64_t` but
-  /// you can pass any integral type (signed or unsigned) except for huge
-  /// `uint64_t`s. The number will be written in a compact form that uses only
-  /// as many bytes as necessary.
   bool FLEncoder_WriteInt(
     FLEncoder arg0,
     int arg1,
@@ -5248,9 +4175,6 @@ class cblite {
   late final _FLEncoder_WriteInt =
       _FLEncoder_WriteIntPtr.asFunction<DartFLEncoder_WriteInt>();
 
-  /// Writes an unsigned integer to an encoder. @note This function is only
-  /// really necessary for huge 64-bit integers greater than or equal to 2^63,
-  /// which can't be represented as int64_t.
   bool FLEncoder_WriteUInt(
     FLEncoder arg0,
     int arg1,
@@ -5267,11 +4191,6 @@ class cblite {
   late final _FLEncoder_WriteUInt =
       _FLEncoder_WriteUIntPtr.asFunction<DartFLEncoder_WriteUInt>();
 
-  /// Writes a 32-bit floating point number to an encoder. @note As an
-  /// implementation detail, if the number has no fractional part and can be
-  /// represented exactly as an integer, it'll be encoded as an integer to save
-  /// space. This is transparent to the reader, since if it requests the value
-  /// as a float it'll be returned as floating-point.
   bool FLEncoder_WriteFloat(
     FLEncoder arg0,
     double arg1,
@@ -5288,10 +4207,6 @@ class cblite {
   late final _FLEncoder_WriteFloat =
       _FLEncoder_WriteFloatPtr.asFunction<DartFLEncoder_WriteFloat>();
 
-  /// Writes a 64-bit floating point number to an encoder. @note As an
-  /// implementation detail, the number may be encoded as a 32-bit float or even
-  /// as an integer, if this can be done without losing precision. For example,
-  /// 123.0 will be written as an integer, and 123.75 as a float.)
   bool FLEncoder_WriteDouble(
     FLEncoder arg0,
     double arg1,
@@ -5308,9 +4223,6 @@ class cblite {
   late final _FLEncoder_WriteDouble =
       _FLEncoder_WriteDoublePtr.asFunction<DartFLEncoder_WriteDouble>();
 
-  /// Writes a string to an encoder. The string must be UTF-8-encoded and must
-  /// not contain any zero bytes. @warning Do _not_ use this to write a
-  /// dictionary key; use FLEncoder_WriteKey instead.
   bool FLEncoder_WriteString(
     FLEncoder arg0,
     FLString arg1,
@@ -5327,13 +4239,6 @@ class cblite {
   late final _FLEncoder_WriteString =
       _FLEncoder_WriteStringPtr.asFunction<DartFLEncoder_WriteString>();
 
-  /// Writes a timestamp to an encoder, as an ISO-8601 date string. @note Since
-  /// neither Fleece nor JSON have a 'Date' type, the encoded string has no
-  /// metadata that distinguishes it as a date. It's just a string.) @param
-  /// encoder The encoder to write to. @param ts The timestamp (milliseconds
-  /// since Unix epoch 1-1-1970). @param asUTC If true, date is written in UTC
-  /// (GMT); if false, with the local timezone. @return True on success, false
-  /// on error.
   bool FLEncoder_WriteDateString(
     FLEncoder encoder,
     int ts,
@@ -5352,9 +4257,6 @@ class cblite {
   late final _FLEncoder_WriteDateString =
       _FLEncoder_WriteDateStringPtr.asFunction<DartFLEncoder_WriteDateString>();
 
-  /// Writes a binary data value (a blob) to an encoder. This can contain
-  /// absolutely anything including null bytes. If the encoder is generating
-  /// JSON, the blob will be written as a base64-encoded string.
   bool FLEncoder_WriteData(
     FLEncoder arg0,
     FLSlice arg1,
@@ -5371,7 +4273,6 @@ class cblite {
   late final _FLEncoder_WriteData =
       _FLEncoder_WriteDataPtr.asFunction<DartFLEncoder_WriteData>();
 
-  /// Writes a Fleece Value to an Encoder.
   bool FLEncoder_WriteValue(
     FLEncoder arg0,
     FLValue arg1,
@@ -5388,11 +4289,6 @@ class cblite {
   late final _FLEncoder_WriteValue =
       _FLEncoder_WriteValuePtr.asFunction<DartFLEncoder_WriteValue>();
 
-  /// Begins writing an array value to an encoder. This pushes a new state where
-  /// each subsequent value written becomes an array item, until
-  /// FLEncoder_EndArray is called. @param reserveCount Number of array elements
-  /// to reserve space for. If you know the size of the array, providing it here
-  /// speeds up encoding slightly. If you don't know, just use zero.
   bool FLEncoder_BeginArray(
     FLEncoder arg0,
     int reserveCount,
@@ -5409,7 +4305,6 @@ class cblite {
   late final _FLEncoder_BeginArray =
       _FLEncoder_BeginArrayPtr.asFunction<DartFLEncoder_BeginArray>();
 
-  /// Ends writing an array value; pops back the previous encoding state.
   bool FLEncoder_EndArray(
     FLEncoder arg0,
   ) {
@@ -5424,13 +4319,6 @@ class cblite {
   late final _FLEncoder_EndArray =
       _FLEncoder_EndArrayPtr.asFunction<DartFLEncoder_EndArray>();
 
-  /// Begins writing a dictionary value to an encoder. This pushes a new state
-  /// where each subsequent key and value written are added to the dictionary,
-  /// until FLEncoder*EndDict is called. Before adding each value, you must call
-  /// FLEncoder_WriteKey (\_not* FLEncoder_WriteString!), to write the
-  /// dictionary key. @param reserveCount Number of dictionary items to reserve
-  /// space for. If you know the size of the dictionary, providing it here
-  /// speeds up encoding slightly. If you don't know, just use zero.
   bool FLEncoder_BeginDict(
     FLEncoder arg0,
     int reserveCount,
@@ -5447,8 +4335,6 @@ class cblite {
   late final _FLEncoder_BeginDict =
       _FLEncoder_BeginDictPtr.asFunction<DartFLEncoder_BeginDict>();
 
-  /// Specifies the key for the next value to be written to the current
-  /// dictionary.
   bool FLEncoder_WriteKey(
     FLEncoder arg0,
     FLString arg1,
@@ -5465,9 +4351,6 @@ class cblite {
   late final _FLEncoder_WriteKey =
       _FLEncoder_WriteKeyPtr.asFunction<DartFLEncoder_WriteKey>();
 
-  /// Specifies the key for the next value to be written to the current
-  /// dictionary. The key is given as a Value, which must be a string or
-  /// integer.
   bool FLEncoder_WriteKeyValue(
     FLEncoder arg0,
     FLValue arg1,
@@ -5484,7 +4367,6 @@ class cblite {
   late final _FLEncoder_WriteKeyValue =
       _FLEncoder_WriteKeyValuePtr.asFunction<DartFLEncoder_WriteKeyValue>();
 
-  /// Ends writing a dictionary value; pops back the previous encoding state.
   bool FLEncoder_EndDict(
     FLEncoder arg0,
   ) {
@@ -5498,10 +4380,6 @@ class cblite {
   late final _FLEncoder_EndDict =
       _FLEncoder_EndDictPtr.asFunction<DartFLEncoder_EndDict>();
 
-  /// Writes raw data directly to the encoded output. (This is not the same as
-  /// \ref FLEncoder_WriteData, which safely encodes a blob.) @warning **Do not
-  /// call this** unless you really know what you're doing ... it's quite
-  /// unsafe, and only used for certain advanced purposes.
   bool FLEncoder_WriteRaw(
     FLEncoder arg0,
     FLSlice arg1,
@@ -5518,10 +4396,6 @@ class cblite {
   late final _FLEncoder_WriteRaw =
       _FLEncoder_WriteRawPtr.asFunction<DartFLEncoder_WriteRaw>();
 
-  /// Ends encoding; if there has been no error, it returns the encoded Fleece
-  /// data packaged in an FLDoc. (This function does not support JSON encoding.)
-  /// This does not free the FLEncoder; call FLEncoder_Free (or FLEncoder_Reset)
-  /// next.
   FLDoc FLEncoder_FinishDoc(
     FLEncoder arg0,
     ffi.Pointer<ffi.UnsignedInt> outError,
@@ -5538,9 +4412,6 @@ class cblite {
   late final _FLEncoder_FinishDoc =
       _FLEncoder_FinishDocPtr.asFunction<DartFLEncoder_FinishDoc>();
 
-  /// Ends encoding; if there has been no error, it returns the encoded data,
-  /// else null. This does not free the FLEncoder; call FLEncoder_Free (or
-  /// FLEncoder_Reset) next.
   FLSliceResult FLEncoder_Finish(
     FLEncoder arg0,
     ffi.Pointer<ffi.UnsignedInt> outError,
@@ -5556,7 +4427,6 @@ class cblite {
   late final _FLEncoder_Finish =
       _FLEncoder_FinishPtr.asFunction<DartFLEncoder_Finish>();
 
-  /// Returns the error code of an encoder, or NoError (0) if there's no error.
   FLError FLEncoder_GetError(
     FLEncoder arg0,
   ) {
@@ -5571,7 +4441,6 @@ class cblite {
   late final _FLEncoder_GetError =
       _FLEncoder_GetErrorPtr.asFunction<DartFLEncoder_GetError>();
 
-  /// Returns the error message of an encoder, or NULL if there's no error.
   ffi.Pointer<ffi.Char> FLEncoder_GetErrorMessage(
     FLEncoder arg0,
   ) {
@@ -5586,8 +4455,6 @@ class cblite {
   late final _FLEncoder_GetErrorMessage =
       _FLEncoder_GetErrorMessagePtr.asFunction<DartFLEncoder_GetErrorMessage>();
 
-  /// Encodes a Fleece value as JSON (or a JSON fragment.) @note Any Data values
-  /// will be encoded as base64-encoded strings.
   FLStringResult FLValue_ToJSON(
     FLValue arg0,
   ) {
@@ -5601,10 +4468,6 @@ class cblite {
   late final _FLValue_ToJSON =
       _FLValue_ToJSONPtr.asFunction<DartFLValue_ToJSON>();
 
-  /// Encodes a Fleece value as JSON5, a more lenient variant of JSON that
-  /// allows dictionary keys to be unquoted if they're alphanumeric. This tends
-  /// to be more readable. @note Any Data values will be encoded as
-  /// base64-encoded strings.
   FLStringResult FLValue_ToJSON5(
     FLValue arg0,
   ) {
@@ -5618,11 +4481,6 @@ class cblite {
   late final _FLValue_ToJSON5 =
       _FLValue_ToJSON5Ptr.asFunction<DartFLValue_ToJSON5>();
 
-  /// Most general Fleece to JSON converter. @param v The Fleece value to encode
-  /// @param json5 If true, outputs JSON5, like \ref FLValue_ToJSON5 @param
-  /// canonicalForm If true, outputs the JSON in a consistent "canonical" form.
-  /// All equivalent values should produce byte-for-byte identical canonical
-  /// JSON. This is useful for creating digital signatures, for example.
   FLStringResult FLValue_ToJSONX(
     FLValue v,
     bool json5,
@@ -5640,9 +4498,6 @@ class cblite {
   late final _FLValue_ToJSONX =
       _FLValue_ToJSONXPtr.asFunction<DartFLValue_ToJSONX>();
 
-  /// Creates an FLDoc from JSON-encoded data. The data is first encoded into
-  /// Fleece, and the Fleece data is kept by the doc; the input JSON data is no
-  /// longer needed after this function returns.
   FLDoc FLDoc_FromJSON(
     FLSlice json,
     ffi.Pointer<ffi.UnsignedInt> outError,
@@ -5658,9 +4513,6 @@ class cblite {
   late final _FLDoc_FromJSON =
       _FLDoc_FromJSONPtr.asFunction<DartFLDoc_FromJSON>();
 
-  /// Creates a new mutable Array from JSON. It is an error if the JSON is not
-  /// an array. Its initial ref-count is 1, so a call to FLMutableArray_Release
-  /// will free it.
   FLMutableArray FLMutableArray_NewFromJSON(
     FLString json,
     ffi.Pointer<ffi.UnsignedInt> outError,
@@ -5677,9 +4529,6 @@ class cblite {
   late final _FLMutableArray_NewFromJSON = _FLMutableArray_NewFromJSONPtr
       .asFunction<DartFLMutableArray_NewFromJSON>();
 
-  /// Creates a new mutable Dict from json. It is an error if the JSON is not a
-  /// dictionary/object. Its initial ref-count is 1, so a call to
-  /// FLMutableDict_Release will free it.
   FLMutableDict FLMutableDict_NewFromJSON(
     FLString json,
     ffi.Pointer<ffi.UnsignedInt> outError,
@@ -5696,9 +4545,6 @@ class cblite {
   late final _FLMutableDict_NewFromJSON =
       _FLMutableDict_NewFromJSONPtr.asFunction<DartFLMutableDict_NewFromJSON>();
 
-  /// Parses JSON data and writes the value(s) to the encoder as their Fleece
-  /// equivalents. (This acts as a single write, like WriteInt; it's just that
-  /// the value written is likely to be an entire dictionary or array.)
   bool FLEncoder_ConvertJSON(
     FLEncoder arg0,
     FLSlice json,
@@ -5715,7 +4561,6 @@ class cblite {
   late final _FLEncoder_ConvertJSON =
       _FLEncoder_ConvertJSONPtr.asFunction<DartFLEncoder_ConvertJSON>();
 
-  /// Creates a new FLKeyPath object by compiling a path specifier string.
   FLKeyPath FLKeyPath_New(
     FLSlice specifier,
     ffi.Pointer<ffi.UnsignedInt> outError,
@@ -5730,7 +4575,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLKeyPath_New>>('FLKeyPath_New');
   late final _FLKeyPath_New = _FLKeyPath_NewPtr.asFunction<DartFLKeyPath_New>();
 
-  /// Frees a compiled FLKeyPath object. (It's ok to pass NULL.)
   void FLKeyPath_Free(
     FLKeyPath arg0,
   ) {
@@ -5744,7 +4588,6 @@ class cblite {
   late final _FLKeyPath_Free =
       _FLKeyPath_FreePtr.asFunction<DartFLKeyPath_Free>();
 
-  /// Evaluates a compiled key-path for a given Fleece root object.
   FLValue FLKeyPath_Eval(
     FLKeyPath arg0,
     FLValue root,
@@ -5760,9 +4603,6 @@ class cblite {
   late final _FLKeyPath_Eval =
       _FLKeyPath_EvalPtr.asFunction<DartFLKeyPath_Eval>();
 
-  /// Evaluates a key-path from a specifier string, for a given Fleece root
-  /// object. If you only need to evaluate the path once, this is a bit faster
-  /// than creating an FLKeyPath object, evaluating, then freeing it.
   FLValue FLKeyPath_EvalOnce(
     FLSlice specifier,
     FLValue root,
@@ -5781,7 +4621,6 @@ class cblite {
   late final _FLKeyPath_EvalOnce =
       _FLKeyPath_EvalOncePtr.asFunction<DartFLKeyPath_EvalOnce>();
 
-  /// Returns a path in string form.
   FLStringResult FLKeyPath_ToString(
     FLKeyPath path,
   ) {
@@ -5796,7 +4635,6 @@ class cblite {
   late final _FLKeyPath_ToString =
       _FLKeyPath_ToStringPtr.asFunction<DartFLKeyPath_ToString>();
 
-  /// Equality test.
   bool FLKeyPath_Equals(
     FLKeyPath path1,
     FLKeyPath path2,
@@ -5812,7 +4650,6 @@ class cblite {
   late final _FLKeyPath_Equals =
       _FLKeyPath_EqualsPtr.asFunction<DartFLKeyPath_Equals>();
 
-  /// Returns an element of a path, either a key or an array index.
   bool FLKeyPath_GetElement(
     FLKeyPath arg0,
     int i,
@@ -5833,7 +4670,6 @@ class cblite {
   late final _FLKeyPath_GetElement =
       _FLKeyPath_GetElementPtr.asFunction<DartFLKeyPath_GetElement>();
 
-  /// A constant null value (like a JSON `null`, not a NULL pointer!)
   late final ffi.Pointer<FLValue> _kFLNullValue =
       _lookup<FLValue>('kFLNullValue');
 
@@ -5841,10 +4677,6 @@ class cblite {
 
   set kFLNullValue(FLValue value) => _kFLNullValue.value = value;
 
-  /// A constant undefined value. This is not a NULL pointer, but its type is
-  /// \ref kFLUndefined. It can be stored in an \ref FLMutableArray or \ref
-  /// FLMutableDict if you really, really need to store an undefined/empty
-  /// value, not just a JSON `null`.
   late final ffi.Pointer<FLValue> _kFLUndefinedValue =
       _lookup<FLValue>('kFLUndefinedValue');
 
@@ -5852,8 +4684,6 @@ class cblite {
 
   set kFLUndefinedValue(FLValue value) => _kFLUndefinedValue.value = value;
 
-  /// Returns the data type of an arbitrary value. If the parameter is a NULL
-  /// pointer, returns `kFLUndefined`.
   FLValueType FLValue_GetType(
     FLValue arg0,
   ) {
@@ -5867,7 +4697,6 @@ class cblite {
   late final _FLValue_GetType =
       _FLValue_GetTypePtr.asFunction<DartFLValue_GetType>();
 
-  /// Returns true if the value is non-NULL and represents an integer.
   bool FLValue_IsInteger(
     FLValue arg0,
   ) {
@@ -5881,10 +4710,6 @@ class cblite {
   late final _FLValue_IsInteger =
       _FLValue_IsIntegerPtr.asFunction<DartFLValue_IsInteger>();
 
-  /// Returns true if the value is non-NULL and represents an integer >= 2^63.
-  /// Such a value can't be represented in C as an `int64_t`, only a `uint64_t`,
-  /// so you should access it by calling `FLValueAsUnsigned`, _not_
-  /// FLValueAsInt, which would return an incorrect (negative) value.
   bool FLValue_IsUnsigned(
     FLValue arg0,
   ) {
@@ -5899,8 +4724,6 @@ class cblite {
   late final _FLValue_IsUnsigned =
       _FLValue_IsUnsignedPtr.asFunction<DartFLValue_IsUnsigned>();
 
-  /// Returns true if the value is non-NULL and represents a 64-bit
-  /// floating-point number.
   bool FLValue_IsDouble(
     FLValue arg0,
   ) {
@@ -5914,8 +4737,6 @@ class cblite {
   late final _FLValue_IsDouble =
       _FLValue_IsDoublePtr.asFunction<DartFLValue_IsDouble>();
 
-  /// Returns a value coerced to boolean. This will be true unless the value is
-  /// NULL (undefined), null, false, or zero.
   bool FLValue_AsBool(
     FLValue arg0,
   ) {
@@ -5929,11 +4750,6 @@ class cblite {
   late final _FLValue_AsBool =
       _FLValue_AsBoolPtr.asFunction<DartFLValue_AsBool>();
 
-  /// Returns a value coerced to an integer. True and false are returned as 1
-  /// and 0, and floating-point numbers are rounded. All other types are
-  /// returned as 0. @warning Large 64-bit unsigned integers (2^63 and above)
-  /// will come out wrong. You can check for these by calling
-  /// `FLValueIsUnsigned`.
   int FLValue_AsInt(
     FLValue arg0,
   ) {
@@ -5946,9 +4762,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLValue_AsInt>>('FLValue_AsInt');
   late final _FLValue_AsInt = _FLValue_AsIntPtr.asFunction<DartFLValue_AsInt>();
 
-  /// Returns a value coerced to an unsigned integer. This is the same as
-  /// `FLValueAsInt` except that it _can't_ handle negative numbers, but does
-  /// correctly return large `uint64_t` values of 2^63 and up.
   int FLValue_AsUnsigned(
     FLValue arg0,
   ) {
@@ -5963,11 +4776,6 @@ class cblite {
   late final _FLValue_AsUnsigned =
       _FLValue_AsUnsignedPtr.asFunction<DartFLValue_AsUnsigned>();
 
-  /// Returns a value coerced to a 32-bit floating point number. True and false
-  /// are returned as 1.0 and 0.0, and integers are converted to float. All
-  /// other types are returned as 0.0. @warning Large integers (outside
-  /// approximately +/- 2^23) will lose precision due to the limitations of IEEE
-  /// 32-bit float format.
   double FLValue_AsFloat(
     FLValue arg0,
   ) {
@@ -5981,11 +4789,6 @@ class cblite {
   late final _FLValue_AsFloat =
       _FLValue_AsFloatPtr.asFunction<DartFLValue_AsFloat>();
 
-  /// Returns a value coerced to a 32-bit floating point number. True and false
-  /// are returned as 1.0 and 0.0, and integers are converted to float. All
-  /// other types are returned as 0.0. @warning Very large integers (outside
-  /// approximately +/- 2^50) will lose precision due to the limitations of IEEE
-  /// 32-bit float format.
   double FLValue_AsDouble(
     FLValue arg0,
   ) {
@@ -5999,7 +4802,6 @@ class cblite {
   late final _FLValue_AsDouble =
       _FLValue_AsDoublePtr.asFunction<DartFLValue_AsDouble>();
 
-  /// Returns the exact contents of a string value, or null for all other types.
   FLString FLValue_AsString(
     FLValue arg0,
   ) {
@@ -6013,11 +4815,6 @@ class cblite {
   late final _FLValue_AsString =
       _FLValue_AsStringPtr.asFunction<DartFLValue_AsString>();
 
-  /// Converts a value to a timestamp, in milliseconds since Unix epoch, or
-  /// INT64_MIN on failure.
-  ///
-  /// - A string is parsed as ISO-8601 (standard JSON date format).
-  /// - A number is interpreted as a timestamp and returned as-is.
   int FLValue_AsTimestamp(
     FLValue arg0,
   ) {
@@ -6032,7 +4829,6 @@ class cblite {
   late final _FLValue_AsTimestamp =
       _FLValue_AsTimestampPtr.asFunction<DartFLValue_AsTimestamp>();
 
-  /// Returns the exact contents of a data value, or null for all other types.
   FLSlice FLValue_AsData(
     FLValue arg0,
   ) {
@@ -6046,7 +4842,6 @@ class cblite {
   late final _FLValue_AsData =
       _FLValue_AsDataPtr.asFunction<DartFLValue_AsData>();
 
-  /// If a FLValue represents an array, returns it cast to FLArray, else NULL.
   FLArray FLValue_AsArray(
     FLValue arg0,
   ) {
@@ -6060,7 +4855,6 @@ class cblite {
   late final _FLValue_AsArray =
       _FLValue_AsArrayPtr.asFunction<DartFLValue_AsArray>();
 
-  /// If a FLValue represents a dictionary, returns it as an FLDict, else NULL.
   FLDict FLValue_AsDict(
     FLValue arg0,
   ) {
@@ -6074,9 +4868,6 @@ class cblite {
   late final _FLValue_AsDict =
       _FLValue_AsDictPtr.asFunction<DartFLValue_AsDict>();
 
-  /// Returns a string representation of any scalar value. Data values are
-  /// returned in raw form. Arrays and dictionaries don't have a representation
-  /// and will return NULL.
   FLStringResult FLValue_ToString(
     FLValue arg0,
   ) {
@@ -6090,7 +4881,6 @@ class cblite {
   late final _FLValue_ToString =
       _FLValue_ToStringPtr.asFunction<DartFLValue_ToString>();
 
-  /// Compares two values for equality. This is a deep recursive comparison.
   bool FLValue_IsEqual(
     FLValue v1,
     FLValue v2,
@@ -6106,7 +4896,6 @@ class cblite {
   late final _FLValue_IsEqual =
       _FLValue_IsEqualPtr.asFunction<DartFLValue_IsEqual>();
 
-  /// Returns true if the value is mutable.
   bool FLValue_IsMutable(
     FLValue arg0,
   ) {
@@ -6120,9 +4909,6 @@ class cblite {
   late final _FLValue_IsMutable =
       _FLValue_IsMutablePtr.asFunction<DartFLValue_IsMutable>();
 
-  /// Increments the ref-count of a mutable value, or of an immutable value's
-  /// \ref FLDoc. @warning It is illegal to call this on a value obtained from
-  /// \ref FLValue_FromData.
   FLValue FLValue_Retain(
     FLValue arg0,
   ) {
@@ -6136,10 +4922,6 @@ class cblite {
   late final _FLValue_Retain =
       _FLValue_RetainPtr.asFunction<DartFLValue_Retain>();
 
-  /// Decrements the ref-count of a mutable value, or of an immutable value's
-  /// \ref FLDoc. If the ref-count reaches zero the corresponding object is
-  /// freed. @warning It is illegal to call this on a value obtained from \ref
-  /// FLValue_FromData.
   void FLValue_Release(
     FLValue arg0,
   ) {
@@ -6153,18 +4935,6 @@ class cblite {
   late final _FLValue_Release =
       _FLValue_ReleasePtr.asFunction<DartFLValue_Release>();
 
-  /// Creates a new mutable Array that's a copy of the source Array. Its initial
-  /// ref-count is 1, so a call to \ref FLMutableArray_Release will free it.
-  ///
-  /// Copying an immutable Array is very cheap (only one small allocation)
-  /// unless the flag \ref kFLCopyImmutables is set.
-  ///
-  /// Copying a mutable Array is cheap if it's a shallow copy; but if \ref
-  /// kFLDeepCopy is set, nested mutable Arrays and Dicts are also copied,
-  /// recursively; if \ref kFLCopyImmutables is also set, immutable values are
-  /// also copied, recursively.
-  ///
-  /// If the source Array is NULL, then NULL is returned.
   FLMutableArray FLArray_MutableCopy(
     FLArray arg0,
     FLCopyFlags arg1,
@@ -6181,8 +4951,6 @@ class cblite {
   late final _FLArray_MutableCopy =
       _FLArray_MutableCopyPtr.asFunction<DartFLArray_MutableCopy>();
 
-  /// Creates a new empty mutable Array. Its initial ref-count is 1, so a call
-  /// to FLMutableArray_Release will free it.
   FLMutableArray FLMutableArray_New() {
     return _FLMutableArray_New();
   }
@@ -6193,8 +4961,6 @@ class cblite {
   late final _FLMutableArray_New =
       _FLMutableArray_NewPtr.asFunction<DartFLMutableArray_New>();
 
-  /// If the Array was created by FLArray_MutableCopy, returns the original
-  /// source Array.
   FLArray FLMutableArray_GetSource(
     FLMutableArray arg0,
   ) {
@@ -6209,8 +4975,6 @@ class cblite {
   late final _FLMutableArray_GetSource =
       _FLMutableArray_GetSourcePtr.asFunction<DartFLMutableArray_GetSource>();
 
-  /// Returns true if the Array has been changed from the source it was copied
-  /// from.
   bool FLMutableArray_IsChanged(
     FLMutableArray arg0,
   ) {
@@ -6225,7 +4989,6 @@ class cblite {
   late final _FLMutableArray_IsChanged =
       _FLMutableArray_IsChangedPtr.asFunction<DartFLMutableArray_IsChanged>();
 
-  /// Sets or clears the mutable Array's "changed" flag.
   void FLMutableArray_SetChanged(
     FLMutableArray arg0,
     bool changed,
@@ -6242,10 +5005,6 @@ class cblite {
   late final _FLMutableArray_SetChanged =
       _FLMutableArray_SetChangedPtr.asFunction<DartFLMutableArray_SetChanged>();
 
-  /// Inserts a contiguous range of JSON `null` values into the array. @param
-  /// array The array to operate on. @param firstIndex The zero-based index of
-  /// the first value to be inserted. @param count The number of items to
-  /// insert.
   void FLMutableArray_Insert(
     FLMutableArray array,
     int firstIndex,
@@ -6264,9 +5023,6 @@ class cblite {
   late final _FLMutableArray_Insert =
       _FLMutableArray_InsertPtr.asFunction<DartFLMutableArray_Insert>();
 
-  /// Removes contiguous items from the array. @param array The array to operate
-  /// on. @param firstIndex The zero-based index of the first item to remove.
-  /// @param count The number of items to remove.
   void FLMutableArray_Remove(
     FLMutableArray array,
     int firstIndex,
@@ -6285,9 +5041,6 @@ class cblite {
   late final _FLMutableArray_Remove =
       _FLMutableArray_RemovePtr.asFunction<DartFLMutableArray_Remove>();
 
-  /// Changes the size of an array. If the new size is larger, the array is
-  /// padded with JSON `null` values. If it's smaller, values are removed from
-  /// the end.
   void FLMutableArray_Resize(
     FLMutableArray array,
     int size,
@@ -6304,12 +5057,6 @@ class cblite {
   late final _FLMutableArray_Resize =
       _FLMutableArray_ResizePtr.asFunction<DartFLMutableArray_Resize>();
 
-  /// Convenience function for getting an array-valued property in mutable form.
-  ///
-  /// - If the value for the key is not an array, returns NULL.
-  /// - If the value is a mutable array, returns it.
-  /// - If the value is an immutable array, this function makes a mutable copy,
-  ///   assigns the copy as the property value, and returns the copy.
   FLMutableArray FLMutableArray_GetMutableArray(
     FLMutableArray arg0,
     int index,
@@ -6327,12 +5074,6 @@ class cblite {
       _FLMutableArray_GetMutableArrayPtr.asFunction<
           DartFLMutableArray_GetMutableArray>();
 
-  /// Convenience function for getting an array-valued property in mutable form.
-  ///
-  /// - If the value for the key is not an array, returns NULL.
-  /// - If the value is a mutable array, returns it.
-  /// - If the value is an immutable array, this function makes a mutable copy,
-  ///   assigns the copy as the property value, and returns the copy.
   FLMutableDict FLMutableArray_GetMutableDict(
     FLMutableArray arg0,
     int index,
@@ -6349,16 +5090,6 @@ class cblite {
   late final _FLMutableArray_GetMutableDict = _FLMutableArray_GetMutableDictPtr
       .asFunction<DartFLMutableArray_GetMutableDict>();
 
-  /// Creates a new mutable Dict that's a copy of the source Dict. Its initial
-  /// ref-count is 1, so a call to FLMutableDict_Release will free it.
-  ///
-  /// Copying an immutable Dict is very cheap (only one small allocation.) The
-  /// `deepCopy` flag is ignored.
-  ///
-  /// Copying a mutable Dict is cheap if it's a shallow copy, but if `deepCopy`
-  /// is true, nested mutable Dicts and Arrays are also copied, recursively.
-  ///
-  /// If the source dict is NULL, then NULL is returned.
   FLMutableDict FLDict_MutableCopy(
     FLDict source,
     FLCopyFlags arg1,
@@ -6375,8 +5106,6 @@ class cblite {
   late final _FLDict_MutableCopy =
       _FLDict_MutableCopyPtr.asFunction<DartFLDict_MutableCopy>();
 
-  /// Creates a new empty mutable Dict. Its initial ref-count is 1, so a call to
-  /// FLMutableDict_Release will free it.
   FLMutableDict FLMutableDict_New() {
     return _FLMutableDict_New();
   }
@@ -6386,8 +5115,6 @@ class cblite {
   late final _FLMutableDict_New =
       _FLMutableDict_NewPtr.asFunction<DartFLMutableDict_New>();
 
-  /// If the Dict was created by FLDict_MutableCopy, returns the original source
-  /// Dict.
   FLDict FLMutableDict_GetSource(
     FLMutableDict arg0,
   ) {
@@ -6402,8 +5129,6 @@ class cblite {
   late final _FLMutableDict_GetSource =
       _FLMutableDict_GetSourcePtr.asFunction<DartFLMutableDict_GetSource>();
 
-  /// Returns true if the Dict has been changed from the source it was copied
-  /// from.
   bool FLMutableDict_IsChanged(
     FLMutableDict arg0,
   ) {
@@ -6418,7 +5143,6 @@ class cblite {
   late final _FLMutableDict_IsChanged =
       _FLMutableDict_IsChangedPtr.asFunction<DartFLMutableDict_IsChanged>();
 
-  /// Sets or clears the mutable Dict's "changed" flag.
   void FLMutableDict_SetChanged(
     FLMutableDict arg0,
     bool arg1,
@@ -6435,7 +5159,6 @@ class cblite {
   late final _FLMutableDict_SetChanged =
       _FLMutableDict_SetChangedPtr.asFunction<DartFLMutableDict_SetChanged>();
 
-  /// Removes the value for a key.
   void FLMutableDict_Remove(
     FLMutableDict arg0,
     FLString key,
@@ -6452,7 +5175,6 @@ class cblite {
   late final _FLMutableDict_Remove =
       _FLMutableDict_RemovePtr.asFunction<DartFLMutableDict_Remove>();
 
-  /// Removes all keys and values.
   void FLMutableDict_RemoveAll(
     FLMutableDict arg0,
   ) {
@@ -6467,12 +5189,6 @@ class cblite {
   late final _FLMutableDict_RemoveAll =
       _FLMutableDict_RemoveAllPtr.asFunction<DartFLMutableDict_RemoveAll>();
 
-  /// Convenience function for getting an array-valued property in mutable form.
-  ///
-  /// - If the value for the key is not an array, returns NULL.
-  /// - If the value is a mutable array, returns it.
-  /// - If the value is an immutable array, this function makes a mutable copy,
-  ///   assigns the copy as the property value, and returns the copy.
   FLMutableArray FLMutableDict_GetMutableArray(
     FLMutableDict arg0,
     FLString key,
@@ -6489,12 +5205,6 @@ class cblite {
   late final _FLMutableDict_GetMutableArray = _FLMutableDict_GetMutableArrayPtr
       .asFunction<DartFLMutableDict_GetMutableArray>();
 
-  /// Convenience function for getting a dict-valued property in mutable form.
-  ///
-  /// - If the value for the key is not a dict, returns NULL.
-  /// - If the value is a mutable dict, returns it.
-  /// - If the value is an immutable dict, this function makes a mutable copy,
-  ///   assigns the copy as the property value, and returns the copy.
   FLMutableDict FLMutableDict_GetMutableDict(
     FLMutableDict arg0,
     FLString key,
@@ -6511,9 +5221,6 @@ class cblite {
   late final _FLMutableDict_GetMutableDict = _FLMutableDict_GetMutableDictPtr
       .asFunction<DartFLMutableDict_GetMutableDict>();
 
-  /// Allocates a string value on the heap. This is rarely needed -- usually
-  /// you'd just add a string to a mutable Array or Dict directly using one of
-  /// their "...SetString" or "...AppendString" methods.
   FLValue FLValue_NewString(
     FLString arg0,
   ) {
@@ -6527,9 +5234,6 @@ class cblite {
   late final _FLValue_NewString =
       _FLValue_NewStringPtr.asFunction<DartFLValue_NewString>();
 
-  /// Allocates a data/blob value on the heap. This is rarely needed -- usually
-  /// you'd just add data to a mutable Array or Dict directly using one of their
-  /// "...SetData or "...AppendData" methods.
   FLValue FLValue_NewData(
     FLSlice arg0,
   ) {
@@ -6543,10 +5247,6 @@ class cblite {
   late final _FLValue_NewData =
       _FLValue_NewDataPtr.asFunction<DartFLValue_NewData>();
 
-  /// Returns an \ref FLSlot that refers to the given index of the given array.
-  /// You store a value to it by calling one of the nine `FLSlot_Set...`
-  /// functions. \warning You should immediately store a value into the
-  /// `FLSlot`. Do not keep it around; any changes to the array invalidate it.
   FLSlot FLMutableArray_Set(
     FLMutableArray arg0,
     int index,
@@ -6563,11 +5263,6 @@ class cblite {
   late final _FLMutableArray_Set =
       _FLMutableArray_SetPtr.asFunction<DartFLMutableArray_Set>();
 
-  /// Appends a null value to the array and returns an \ref FLSlot that refers
-  /// to that position. You store a value to it by calling one of the nine
-  /// `FLSlot_Set...` functions. \warning You should immediately store a value
-  /// into the `FLSlot`. Do not keep it around; any changes to the array
-  /// invalidate it.
   FLSlot FLMutableArray_Append(
     FLMutableArray arg0,
   ) {
@@ -6582,11 +5277,6 @@ class cblite {
   late final _FLMutableArray_Append =
       _FLMutableArray_AppendPtr.asFunction<DartFLMutableArray_Append>();
 
-  /// Returns an \ref FLSlot that refers to the given key/value pair of the
-  /// given dictionary. You store a value to it by calling one of the nine
-  /// `FLSlot_Set...` functions. \warning You should immediately store a value
-  /// into the `FLSlot`. Do not keep it around; any changes to the dictionary
-  /// invalidate it.
   FLSlot FLMutableDict_Set(
     FLMutableDict arg0,
     FLString key,
@@ -6734,12 +5424,6 @@ class cblite {
   late final _FLSlot_SetValue =
       _FLSlot_SetValuePtr.asFunction<DartFLSlot_SetValue>();
 
-  /// Returns JSON that encodes the changes to turn the value `old` into `nuu`.
-  /// (The format is documented in Fleece.md, but you should treat it as a black
-  /// box.) @param old A value that's typically the old/original state of some
-  /// data. @param nuu A value that's typically the new/changed state of the
-  /// `old` data. @return JSON data representing the changes from `old` to
-  /// `nuu`, or NULL on (extremely unlikely) failure.
   FLSliceResult FLCreateJSONDelta(
     FLValue old,
     FLValue nuu,
@@ -6755,13 +5439,6 @@ class cblite {
   late final _FLCreateJSONDelta =
       _FLCreateJSONDeltaPtr.asFunction<DartFLCreateJSONDelta>();
 
-  /// Writes JSON that describes the changes to turn the value `old` into `nuu`.
-  /// (The format is documented in Fleece.md, but you should treat it as a black
-  /// box.) @param old A value that's typically the old/original state of some
-  /// data. @param nuu A value that's typically the new/changed state of the
-  /// `old` data. @param jsonEncoder An encoder to write the JSON to. Must have
-  /// been created using `FLEncoder_NewWithOptions`, with JSON or JSON5 format.
-  /// @return True on success, false on (extremely unlikely) failure.
   bool FLEncodeJSONDelta(
     FLValue old,
     FLValue nuu,
@@ -6779,16 +5456,6 @@ class cblite {
   late final _FLEncodeJSONDelta =
       _FLEncodeJSONDeltaPtr.asFunction<DartFLEncodeJSONDelta>();
 
-  /// Applies the JSON data created by `CreateJSONDelta` to the value `old`,
-  /// which must be equal to the `old` value originally passed to
-  /// `FLCreateJSONDelta`, and returns a Fleece document equal to the original
-  /// `nuu` value. @param old A value that's typically the old/original state of
-  /// some data. This must be equal to the `old` value used when creating the
-  /// `jsonDelta`. @param jsonDelta A JSON-encoded delta created by
-  /// `FLCreateJSONDelta` or `FLEncodeJSONDelta`. @param outError On failure,
-  /// error information will be stored where this points, if non-null. @return
-  /// The corresponding `nuu` value, encoded as Fleece, or null if an error
-  /// occurred.
   FLSliceResult FLApplyJSONDelta(
     FLValue old,
     FLSlice jsonDelta,
@@ -6806,16 +5473,6 @@ class cblite {
   late final _FLApplyJSONDelta =
       _FLApplyJSONDeltaPtr.asFunction<DartFLApplyJSONDelta>();
 
-  /// Applies the (parsed) JSON data created by `CreateJSONDelta` to the value
-  /// `old`, which must be equal to the `old` value originally passed to
-  /// `FLCreateJSONDelta`, and writes the corresponding `nuu` value to the
-  /// encoder. @param old A value that's typically the old/original state of
-  /// some data. This must be equal to the `old` value used when creating the
-  /// `jsonDelta`. @param jsonDelta A JSON-encoded delta created by
-  /// `FLCreateJSONDelta` or `FLEncodeJSONDelta`. @param encoder A Fleece
-  /// encoder to write the decoded `nuu` value to. (JSON encoding is not
-  /// supported.) @return True on success, false on error; call
-  /// `FLEncoder_GetError` for details.
   bool FLEncodeApplyingJSONDelta(
     FLValue old,
     FLSlice jsonDelta,
@@ -6834,8 +5491,6 @@ class cblite {
   late final _FLEncodeApplyingJSONDelta =
       _FLEncodeApplyingJSONDeltaPtr.asFunction<DartFLEncodeApplyingJSONDelta>();
 
-  /// Creates a new empty FLSharedKeys object, which must eventually be
-  /// released.
   FLSharedKeys FLSharedKeys_New() {
     return _FLSharedKeys_New();
   }
@@ -6861,8 +5516,6 @@ class cblite {
   late final _FLSharedKeys_NewWithRead =
       _FLSharedKeys_NewWithReadPtr.asFunction<DartFLSharedKeys_NewWithRead>();
 
-  /// Returns a data blob containing the current state (all the keys and their
-  /// integers.)
   FLSliceResult FLSharedKeys_GetStateData(
     FLSharedKeys arg0,
   ) {
@@ -6877,9 +5530,6 @@ class cblite {
   late final _FLSharedKeys_GetStateData =
       _FLSharedKeys_GetStateDataPtr.asFunction<DartFLSharedKeys_GetStateData>();
 
-  /// Updates an FLSharedKeys with saved state data created by \ref
-  /// FLSharedKeys_GetStateData. Returns true if new keys were added, false if
-  /// not.
   bool FLSharedKeys_LoadStateData(
     FLSharedKeys arg0,
     FLSlice arg1,
@@ -6896,8 +5546,6 @@ class cblite {
   late final _FLSharedKeys_LoadStateData = _FLSharedKeys_LoadStateDataPtr
       .asFunction<DartFLSharedKeys_LoadStateData>();
 
-  /// Writes the current state to a Fleece encoder as a single value, which can
-  /// later be decoded and passed to \ref FLSharedKeys_LoadState.
   void FLSharedKeys_WriteState(
     FLSharedKeys arg0,
     FLEncoder arg1,
@@ -6914,8 +5562,6 @@ class cblite {
   late final _FLSharedKeys_WriteState =
       _FLSharedKeys_WriteStatePtr.asFunction<DartFLSharedKeys_WriteState>();
 
-  /// Updates an FLSharedKeys object with saved state, a Fleece value previously
-  /// written by \ref FLSharedKeys_WriteState.
   bool FLSharedKeys_LoadState(
     FLSharedKeys arg0,
     FLValue arg1,
@@ -6932,12 +5578,6 @@ class cblite {
   late final _FLSharedKeys_LoadState =
       _FLSharedKeys_LoadStatePtr.asFunction<DartFLSharedKeys_LoadState>();
 
-  /// Maps a key string to a number in the range [0...2047], or returns -1 if it
-  /// isn't mapped. If the key doesn't already have a mapping, and the `add`
-  /// flag is true, a new mapping is assigned and returned. However, the `add`
-  /// flag has no effect if the key is unmappable (is longer than 16 bytes or
-  /// contains non-identifier characters), or if all available integers have
-  /// been assigned.
   int FLSharedKeys_Encode(
     FLSharedKeys arg0,
     FLString arg1,
@@ -6956,7 +5596,6 @@ class cblite {
   late final _FLSharedKeys_Encode =
       _FLSharedKeys_EncodePtr.asFunction<DartFLSharedKeys_Encode>();
 
-  /// Returns the key string that maps to the given integer `key`, else NULL.
   FLString FLSharedKeys_Decode(
     FLSharedKeys arg0,
     int key,
@@ -6973,8 +5612,6 @@ class cblite {
   late final _FLSharedKeys_Decode =
       _FLSharedKeys_DecodePtr.asFunction<DartFLSharedKeys_Decode>();
 
-  /// Returns the number of keys in the mapping. This number increases whenever
-  /// the mapping is changed, and never decreases.
   int FLSharedKeys_Count(
     FLSharedKeys arg0,
   ) {
@@ -6989,8 +5626,6 @@ class cblite {
   late final _FLSharedKeys_Count =
       _FLSharedKeys_CountPtr.asFunction<DartFLSharedKeys_Count>();
 
-  /// Reverts an FLSharedKeys by "forgetting" any keys added since it had the
-  /// count `oldCount`.
   void FLSharedKeys_RevertToCount(
     FLSharedKeys arg0,
     int oldCount,
@@ -7007,7 +5642,6 @@ class cblite {
   late final _FLSharedKeys_RevertToCount = _FLSharedKeys_RevertToCountPtr
       .asFunction<DartFLSharedKeys_RevertToCount>();
 
-  /// Disable caching of the SharedKeys..
   void FLSharedKeys_DisableCaching(
     FLSharedKeys arg0,
   ) {
@@ -7022,7 +5656,6 @@ class cblite {
   late final _FLSharedKeys_DisableCaching = _FLSharedKeys_DisableCachingPtr
       .asFunction<DartFLSharedKeys_DisableCaching>();
 
-  /// Increments the reference count of an FLSharedKeys.
   FLSharedKeys FLSharedKeys_Retain(
     FLSharedKeys arg0,
   ) {
@@ -7037,8 +5670,6 @@ class cblite {
   late final _FLSharedKeys_Retain =
       _FLSharedKeys_RetainPtr.asFunction<DartFLSharedKeys_Retain>();
 
-  /// Decrements the reference count of an FLSharedKeys, freeing it when it
-  /// reaches zero.
   void FLSharedKeys_Release(
     FLSharedKeys arg0,
   ) {
@@ -7053,9 +5684,6 @@ class cblite {
   late final _FLSharedKeys_Release =
       _FLSharedKeys_ReleasePtr.asFunction<DartFLSharedKeys_Release>();
 
-  /// Registers a range of memory containing Fleece data that uses the given
-  /// shared keys. This allows Dict accessors to look up the values of shared
-  /// keys.
   FLSharedKeyScope FLSharedKeyScope_WithRange(
     FLSlice range,
     FLSharedKeys arg1,
@@ -7072,7 +5700,6 @@ class cblite {
   late final _FLSharedKeyScope_WithRange = _FLSharedKeyScope_WithRangePtr
       .asFunction<DartFLSharedKeyScope_WithRange>();
 
-  /// Unregisters a scope created by \ref FLSharedKeyScope_WithRange.
   void FLSharedKeyScope_Free(
     FLSharedKeyScope arg0,
   ) {
@@ -7087,18 +5714,6 @@ class cblite {
   late final _FLSharedKeyScope_Free =
       _FLSharedKeyScope_FreePtr.asFunction<DartFLSharedKeyScope_Free>();
 
-  /// Returns a pointer to the root value in the encoded data, or NULL if
-  /// validation failed. You should generally use an \ref FLDoc instead; it's
-  /// safer. Here's why:
-  ///
-  /// On the plus side, \ref FLValue*FromData is \_extremely* fast: it allocates
-  /// no memory, only scans enough of the data to ensure it's valid (and if
-  /// `trust` is set to `kFLTrusted`, it doesn't even do that.)
-  ///
-  /// But it's potentially _very_ dangerous: the FLValue, and all values found
-  /// through it, are only valid as long as the input `data` remains intact and
-  /// unchanged. If you violate that, the values will be pointing to garbage and
-  /// Bad Things will happen when you access them...
   FLValue FLValue_FromData(
     FLSlice data,
     FLTrust trust,
@@ -7114,19 +5729,6 @@ class cblite {
   late final _FLValue_FromData =
       _FLValue_FromDataPtr.asFunction<DartFLValue_FromData>();
 
-  /// Converts valid JSON5 <https://json5.org> to JSON. Among other things, it
-  /// converts single quotes to double, adds missing quotes around dictionary
-  /// keys, removes trailing commas, and removes comments. @note If given
-  /// invalid JSON5, it will _usually_ return an error, but may just ouput
-  /// comparably invalid JSON, in which case the caller's subsequent JSON
-  /// parsing will detect the error. The types of errors it overlooks tend to be
-  /// subtleties of string or number encoding. @param json5 The JSON5 to parse
-  /// @param outErrorMessage On failure, the error message will be stored here
-  /// (if not NULL.) As this is a \ref FLStringResult, you will be responsible
-  /// for freeing it. @param outErrorPos On a parse error, the byte offset in
-  /// the input where the error occurred will be stored here (if it's not NULL.)
-  /// @param outError On failure, the error code will be stored here (if it's
-  /// not NULL.) @return The converted JSON.
   FLStringResult FLJSON5_ToJSON(
     FLString json5,
     ffi.Pointer<FLStringResult> outErrorMessage,
@@ -7146,8 +5748,6 @@ class cblite {
   late final _FLJSON5_ToJSON =
       _FLJSON5_ToJSONPtr.asFunction<DartFLJSON5_ToJSON>();
 
-  /// Directly converts JSON data to Fleece-encoded data. Not commonly needed.
-  /// Prefer \ref FLDoc_FromJSON instead.
   FLSliceResult FLData_ConvertJSON(
     FLSlice json,
     ffi.Pointer<ffi.UnsignedInt> outError,
@@ -7164,20 +5764,6 @@ class cblite {
   late final _FLData_ConvertJSON =
       _FLData_ConvertJSONPtr.asFunction<DartFLData_ConvertJSON>();
 
-  /// Tells the encoder to logically append to the given Fleece document, rather
-  /// than making a standalone document. Any calls to FLEncoder*WriteValue()
-  /// where the value points inside the base data will write a pointer back to
-  /// the original value. The resulting data returned by FLEncoder_FinishDoc()
-  /// will \_NOT* be standalone; it can only be used by first appending it to
-  /// the base data. @param e The FLEncoder affected. @param base The base
-  /// document to create an amendment of. @param reuseStrings If true, then
-  /// writing a string that already exists in the base will just create a
-  /// pointer back to the original. But the encoder has to scan the base for
-  /// strings first. @param externPointers If true, pointers into the base will
-  /// be marked with the `extern` flag. This allows them to be resolved using
-  /// the `FLResolver_Begin` function, so that when the delta is used the base
-  /// document can be anywhere in memory, not just immediately preceding the
-  /// delta document.
   void FLEncoder_Amend(
     FLEncoder e,
     FLSlice base,
@@ -7197,7 +5783,6 @@ class cblite {
   late final _FLEncoder_Amend =
       _FLEncoder_AmendPtr.asFunction<DartFLEncoder_Amend>();
 
-  /// Returns the `base` value passed to FLEncoder_Amend.
   FLSlice FLEncoder_GetBase(
     FLEncoder arg0,
   ) {
@@ -7211,8 +5796,6 @@ class cblite {
   late final _FLEncoder_GetBase =
       _FLEncoder_GetBasePtr.asFunction<DartFLEncoder_GetBase>();
 
-  /// Tells the encoder not to write the two-byte Fleece trailer at the end of
-  /// the data. This is only useful for certain special purposes.
   void FLEncoder_SuppressTrailer(
     FLEncoder arg0,
   ) {
@@ -7227,9 +5810,6 @@ class cblite {
   late final _FLEncoder_SuppressTrailer =
       _FLEncoder_SuppressTrailerPtr.asFunction<DartFLEncoder_SuppressTrailer>();
 
-  /// Returns the byte offset in the encoded data where the next value will be
-  /// written. (Due to internal buffering, this is not the same as
-  /// FLEncoder_BytesWritten.)
   int FLEncoder_GetNextWritePos(
     FLEncoder arg0,
   ) {
@@ -7244,10 +5824,6 @@ class cblite {
   late final _FLEncoder_GetNextWritePos =
       _FLEncoder_GetNextWritePosPtr.asFunction<DartFLEncoder_GetNextWritePos>();
 
-  /// Returns an opaque reference to the last complete value written to the
-  /// encoder, if possible. Fails (returning kFLNoWrittenValue) if nothing has
-  /// been written, or if the value is inline and can't be referenced this way
-  /// -- that only happens with small scalars or empty collections.
   int FLEncoder_LastValueWritten(
     FLEncoder arg0,
   ) {
@@ -7262,11 +5838,6 @@ class cblite {
   late final _FLEncoder_LastValueWritten = _FLEncoder_LastValueWrittenPtr
       .asFunction<DartFLEncoder_LastValueWritten>();
 
-  /// Writes another reference (a "pointer") to an already-written value, given
-  /// a reference previously returned from \ref FLEncoder_LastValueWritten. The
-  /// effect is exactly the same as if you wrote the entire value again, except
-  /// that the size of the encoded data only grows by 4 bytes. Returns false if
-  /// the reference couldn't be written.
   bool FLEncoder_WriteValueAgain(
     FLEncoder arg0,
     int preWrittenValue,
@@ -7283,11 +5854,6 @@ class cblite {
   late final _FLEncoder_WriteValueAgain =
       _FLEncoder_WriteValueAgainPtr.asFunction<DartFLEncoder_WriteValueAgain>();
 
-  /// Returns the data written so far as a standalone Fleece document, whose
-  /// root is the last value written. You can continue writing, and the final
-  /// output returned by \ref FLEncoder_Finish will consist of everything after
-  /// this point. That second part can be used in the future by loading it as an
-  /// `FLDoc` with the first part as its `extern` reference.
   FLSliceResult FLEncoder_Snip(
     FLEncoder arg0,
   ) {
@@ -7301,8 +5867,6 @@ class cblite {
   late final _FLEncoder_Snip =
       _FLEncoder_SnipPtr.asFunction<DartFLEncoder_Snip>();
 
-  /// Finishes encoding the current item, and returns its offset in the output
-  /// data.
   int FLEncoder_FinishItem(
     FLEncoder arg0,
   ) {
@@ -7317,9 +5881,6 @@ class cblite {
   late final _FLEncoder_FinishItem =
       _FLEncoder_FinishItemPtr.asFunction<DartFLEncoder_FinishItem>();
 
-  /// In a JSON encoder, adds a newline ('\n') and prepares to start encoding
-  /// another top-level object. The encoder MUST be not be within an array or
-  /// dict. Has no effect in a Fleece encoder.
   void FLJSONEncoder_NextDocument(
     FLEncoder arg0,
   ) {
@@ -7334,8 +5895,6 @@ class cblite {
   late final _FLJSONEncoder_NextDocument = _FLJSONEncoder_NextDocumentPtr
       .asFunction<DartFLJSONEncoder_NextDocument>();
 
-  /// Debugging function that returns a C string of JSON. Does not free the
-  /// string's memory!
   ffi.Pointer<ffi.Char> FLDump(
     FLValue arg0,
   ) {
@@ -7347,8 +5906,6 @@ class cblite {
   late final _FLDumpPtr = _lookup<ffi.NativeFunction<NativeFLDump>>('FLDump');
   late final _FLDump = _FLDumpPtr.asFunction<DartFLDump>();
 
-  /// Debugging function that parses Fleece data and returns a C string of JSON.
-  /// Does not free the string's memory!
   ffi.Pointer<ffi.Char> FLDumpData(
     FLSlice data,
   ) {
@@ -7361,8 +5918,6 @@ class cblite {
       _lookup<ffi.NativeFunction<NativeFLDumpData>>('FLDumpData');
   late final _FLDumpData = _FLDumpDataPtr.asFunction<DartFLDumpData>();
 
-  /// Produces a human-readable dump of Fleece-encoded data. This is only useful
-  /// if you already know, or want to learn, the encoding format.
   FLStringResult FLData_Dump(
     FLSlice data,
   ) {
@@ -7395,28 +5950,17 @@ class _SymbolAddresses {
       get FLSharedKeys_Release => _library._FLSharedKeys_ReleasePtr;
 }
 
-/// Error domains, serving as namespaces for numeric error codes.
 typedef CBLErrorDomain = ffi.Uint8;
 typedef DartCBLErrorDomain = int;
-
-/// Couchbase Lite error codes, in the CBLDomain.
 typedef CBLErrorCode = ffi.Int32;
 typedef DartCBLErrorCode = int;
-
-/// Network error codes, in the CBLNetworkDomain.
 typedef CBLNetworkErrorCode = ffi.Int32;
 typedef DartCBLNetworkErrorCode = int;
 
-/// A struct holding information about an error. It's declared on the stack by a
-/// caller, and its address is passed to an API function. If the function's
-/// return value indicates that there was an error (usually by returning NULL or
-/// false), then the CBLError will have been filled in with the details.
 final class CBLError extends ffi.Struct {
-  /// < Domain of errors; a namespace for the `code`.
   @CBLErrorDomain()
   external int domain;
 
-  /// < Error code, specific to the domain. 0 always means no error.
   @ffi.Int()
   external int code;
 
@@ -7424,13 +5968,6 @@ final class CBLError extends ffi.Struct {
   external int internal_info;
 }
 
-/// A heap-allocated block of memory returned from an API call. The caller takes
-/// ownership, and must call \ref FLSliceResult_Release when done with it.
-/// \warning The contents of the block must not be modified, since others may be
-/// using it. \note This is equivalent to the C++ class `alloc_slice`. In C++
-/// the easiest way to deal with a `FLSliceResult` return value is to construct
-/// an `alloc_slice` from it, which will adopt the reference, and release it in
-/// its destructor. For example: `alloc_slice foo( CopyFoo() );`
 final class FLSliceResult extends ffi.Struct {
   external ffi.Pointer<ffi.Void> buf;
 
@@ -7442,10 +5979,6 @@ typedef NativeCBLError_Message = FLSliceResult Function(
     ffi.Pointer<CBLError> outError);
 typedef DartCBLError_Message = FLSliceResult Function(
     ffi.Pointer<CBLError> outError);
-
-/// A date/time representation used for document expiration (and in date/time
-/// queries.) Measured in milliseconds since the Unix epoch (1/1/1970, midnight
-/// UTC.)
 typedef CBLTimestamp = ffi.Int64;
 typedef DartCBLTimestamp = int;
 typedef NativeCBL_Now = CBLTimestamp Function();
@@ -7493,8 +6026,6 @@ typedef NativeCBLListener_Remove = ffi.Void Function(
 typedef DartCBLListener_Remove = void Function(
     ffi.Pointer<CBLListenerToken> arg0);
 
-/// A simple reference to a block of memory. Does not imply ownership. (This is
-/// equivalent to the C++ class `slice`.)
 final class FLSlice extends ffi.Struct {
   external ffi.Pointer<ffi.Void> buf;
 
@@ -7545,8 +6076,6 @@ typedef DartCBLBlobReader_Read = int Function(
     ffi.Pointer<ffi.Void> dst,
     int maxLength,
     ffi.Pointer<CBLError> outError);
-
-/// Defines the interpretation of `offset` in \ref CBLBlobReader_Seek.
 typedef CBLSeekBase = ffi.Uint8;
 typedef DartCBLSeekBase = int;
 typedef NativeCBLBlobReader_Seek = ffi.Int64 Function(
@@ -7622,8 +6151,6 @@ typedef NativeCBLDatabase_SaveBlob = ffi.Bool Function(
     ffi.Pointer<CBLError> outError);
 typedef DartCBLDatabase_SaveBlob = bool Function(ffi.Pointer<CBLDatabase> db,
     ffi.Pointer<CBLBlob> blob, ffi.Pointer<CBLError> outError);
-
-/// Conflict-handling options when saving or deleting a document.
 typedef CBLConcurrencyControl = ffi.Uint8;
 typedef DartCBLConcurrencyControl = int;
 typedef CBLConflictHandlerFunction = ffi.Bool Function(
@@ -7634,20 +6161,6 @@ typedef DartCBLConflictHandlerFunction = bool Function(
     ffi.Pointer<ffi.Void> context,
     ffi.Pointer<CBLDocument> documentBeingSaved,
     ffi.Pointer<CBLDocument> conflictingDocument);
-
-/// Custom conflict handler for use when saving or deleting a document. This
-/// handler is called if the save would cause a conflict, i.e. if the document
-/// in the database has been updated (probably by a pull replicator, or by
-/// application code on another thread) since it was loaded into the CBLDocument
-/// being saved. @param context The value of the \p context parameter you passed
-/// to \ref CBLDatabase_SaveDocumentWithConflictHandler. @param
-/// documentBeingSaved The document being saved (same as the parameter you
-/// passed to \ref CBLDatabase_SaveDocumentWithConflictHandler.) The callback
-/// may modify this document's properties as necessary to resolve the conflict.
-/// @param conflictingDocument The revision of the document currently in the
-/// database, which has been changed since \p documentBeingSaved was loaded. May
-/// be NULL, meaning that the document has been deleted. @return True to save
-/// the document, false to abort the save.
 typedef CBLConflictHandler
     = ffi.Pointer<ffi.NativeFunction<CBLConflictHandlerFunction>>;
 typedef NativeCBLDatabase_GetDocument = ffi.Pointer<CBLDocument> Function(
@@ -7795,15 +6308,6 @@ typedef CBLDocumentChangeListenerFunction = ffi.Void Function(
     ffi.Pointer<ffi.Void> context, ffi.Pointer<CBLDatabase> db, FLString docID);
 typedef DartCBLDocumentChangeListenerFunction = void Function(
     ffi.Pointer<ffi.Void> context, ffi.Pointer<CBLDatabase> db, FLString docID);
-
-/// A document change listener callback, invoked after a specific document is
-/// changed on disk. @warning By default, this listener may be called on
-/// arbitrary threads. If your code isn't prepared for that, you may want to use
-/// \ref CBLDatabase_BufferNotifications so that listeners will be called in a
-/// safe context. @warning <b>Deprecated :</b> Use CBLCollectionChangeListener
-/// instead. @param context An arbitrary value given when the callback was
-/// registered. @param db The database containing the document. @param docID The
-/// document's ID.
 typedef CBLDocumentChangeListener
     = ffi.Pointer<ffi.NativeFunction<CBLDocumentChangeListenerFunction>>;
 typedef NativeCBLDatabase_AddDocumentChangeListener
@@ -7818,52 +6322,25 @@ typedef DartCBLDatabase_AddDocumentChangeListener
         FLString docID,
         CBLDocumentChangeListener listener,
         ffi.Pointer<ffi.Void> context);
-
-/// Supported Query languages
 typedef CBLQueryLanguage = ffi.Uint32;
 typedef DartCBLQueryLanguage = int;
 
-/// Value Index Configuration.
 final class CBLValueIndexConfiguration extends ffi.Struct {
-  /// The language used in the expressions.
   @CBLQueryLanguage()
   external int expressionLanguage;
 
-  /// The expressions describing each coloumn of the index. The expressions
-  /// could be specified in a JSON Array or in N1QL syntax using comma
-  /// delimiter.
   external FLString expressions;
 }
 
-/// Full-Text Index Configuration.
 final class CBLFullTextIndexConfiguration extends ffi.Struct {
-  /// The language used in the expressions (Required).
   @CBLQueryLanguage()
   external int expressionLanguage;
 
-  /// The expressions describing each coloumn of the index. The expressions
-  /// could be specified in a JSON Array or in N1QL syntax using comma
-  /// delimiter. (Required)
   external FLString expressions;
 
-  /// Should diacritical marks (accents) be ignored? Defaults to \ref
-  /// kCBLDefaultFullTextIndexIgnoreAccents. Generally this should be left
-  /// `false` for non-English text.
   @ffi.Bool()
   external bool ignoreAccents;
 
-  /// The dominant language. Setting this enables word stemming, i.e. matching
-  /// different cases of the same word ("big" and "bigger", for instance) and
-  /// ignoring common "stop-words" ("the", "a", "of", etc.)
-  ///
-  /// Can be an ISO-639 language code or a lowercase (English) language name;
-  /// supported languages are: da/danish, nl/dutch, en/english, fi/finnish,
-  /// fr/french, de/german, hu/hungarian, it/italian, no/norwegian,
-  /// pt/portuguese, ro/romanian, ru/russian, es/spanish, sv/swedish,
-  /// tr/turkish.
-  ///
-  /// If left null, or set to an unrecognized language, no language-specific
-  /// behaviors such as stemming and stop-word removal occur.
   external FLString language;
 }
 
@@ -7873,8 +6350,6 @@ typedef NativeCBLVectorEncoding_CreateNone = ffi.Pointer<CBLVectorEncoding>
     Function();
 typedef DartCBLVectorEncoding_CreateNone = ffi.Pointer<CBLVectorEncoding>
     Function();
-
-/// Scalar Quantizer encoding type
 typedef CBLScalarQuantizerType = ffi.Uint32;
 typedef DartCBLScalarQuantizerType = int;
 typedef NativeCBLVectorEncoding_CreateScalarQuantizer
@@ -7890,91 +6365,35 @@ typedef NativeCBLVectorEncoding_Free = ffi.Void Function(
     ffi.Pointer<CBLVectorEncoding> arg0);
 typedef DartCBLVectorEncoding_Free = void Function(
     ffi.Pointer<CBLVectorEncoding> arg0);
-
-/// Distance metric to use in CBLVectorIndexConfiguration.
 typedef CBLDistanceMetric = ffi.Uint32;
 typedef DartCBLDistanceMetric = int;
 
-/// ENTERPRISE EDITION ONLY
-///
-/// Vector Index Configuration.
 final class CBLVectorIndexConfiguration extends ffi.Struct {
-  /// The language used in the expressions (Required).
   @CBLQueryLanguage()
   external int expressionLanguage;
 
-  /// The expression could be specified in a JSON Array or in N1QL syntax
-  /// depending on the expressionLanguage. (Required)
-  ///
-  /// For non-lazy indexes, an expression returning either a vector, which is an
-  /// array of 32-bit floating-point numbers, or a Base64 string representing an
-  /// array of 32-bit floating-point numbers in little-endian order.
-  ///
-  /// For lazy indexex, an expression returning a value for computing a vector
-  /// lazily when using \ref CBLIndexUpdater to add or update the vector into
-  /// the index.
   external FLString expression;
 
-  /// The number of vector dimensions. (Required) @note The maximum number of
-  /// vector dimensions supported is 4096.
   @ffi.UnsignedInt()
   external int dimensions;
 
-  /// The number of centroids which is the number buckets to partition the
-  /// vectors in the index. (Required) @note The recommended number of centroids
-  /// is the square root of the number of vectors to be indexed, and the maximum
-  /// number of centroids supported is 64,000.
   @ffi.UnsignedInt()
   external int centroids;
 
-  /// The boolean flag indicating that index is lazy or not. The default value
-  /// is false.
-  ///
-  /// If the index is lazy, it will not be automatically updated when the
-  /// documents in the collection are changed, except when the documents are
-  /// deleted or purged.
-  ///
-  /// When configuring the index to be lazy, the expression set to the config is
-  /// the expression that returns a value used for computing the vector.
-  ///
-  /// To update the lazy index, use a CBLIndexUpdater object, which can be
-  /// obtained from a CBLQueryIndex object. To get a CBLQueryIndex object, call
-  /// CBLCollection_GetIndex.
   @ffi.Bool()
   external bool isLazy;
 
-  /// Vector encoding type. The default value is 8-bits Scalar Quantizer.
   external ffi.Pointer<CBLVectorEncoding> encoding;
 
-  /// Distance Metric type. The default value is euclidean distance.
   @CBLDistanceMetric()
   external int metric;
 
-  /// The minimum number of vectors for training the index. The default value is
-  /// zero, meaning that minTrainingSize will be determined based on the number
-  /// of centroids, encoding types, and the encoding parameters.
-  ///
-  /// @note The training will occur at or before the APPROX_VECTOR_DISANCE query
-  /// is executed, provided there is enough data at that time, and consequently,
-  /// if training is triggered during a query, the query may take longer to
-  /// return results.
-  ///
-  /// @note If a query is executed against the index before it is trained, a
-  /// full scan of the vectors will be performed. If there are insufficient
-  /// vectors in the database for training, a warning message will be logged,
-  /// indicating the required number of vectors.
   @ffi.UnsignedInt()
   external int minTrainingSize;
 
-  /// The maximum number of vectors used for training the index. The default
-  /// value is zero, meaning that the maxTrainingSize will be determined based
-  /// on the number of centroids, encoding types, and encoding parameters.
   @ffi.UnsignedInt()
   external int maxTrainingSize;
 
-  /// The number of centroids that will be scanned during a query. The default
-  /// value is zero, meaning that the numProbes will be determined based on the
-  /// number of centroids.
   @ffi.UnsignedInt()
   external int numProbes;
 }
@@ -8210,22 +6629,12 @@ typedef DartCBLCollection_GetIndex = ffi.Pointer<CBLQueryIndex> Function(
     FLString name,
     ffi.Pointer<CBLError> outError);
 
-/// \name Change Listeners @{ A collection change listener lets you detect
-/// changes made to all documents in a collection. (If you want to observe
-/// specific documents, use a \ref CBLCollectionDocumentChangeListener instead.)
-/// @note If there are multiple \ref CBLCollection instances on the same
-/// database file, each one's listeners will be notified of changes made by
-/// other collection instances. @warning Changes made to the database file by
-/// other processes will _not_ be notified.
 final class CBLCollectionChange extends ffi.Struct {
-  /// <The collection that changed.
   external ffi.Pointer<CBLCollection> collection;
 
-  /// < The number of documents that changed (size of the `docIDs` array).
   @ffi.UnsignedInt()
   external int numDocs;
 
-  /// <The IDs of the documents that changed.
   external ffi.Pointer<FLString> docIDs;
 }
 
@@ -8233,13 +6642,6 @@ typedef CBLCollectionChangeListenerFunction = ffi.Void Function(
     ffi.Pointer<ffi.Void> context, ffi.Pointer<CBLCollectionChange> change);
 typedef DartCBLCollectionChangeListenerFunction = void Function(
     ffi.Pointer<ffi.Void> context, ffi.Pointer<CBLCollectionChange> change);
-
-/// A collection change listener callback, invoked after one or more documents
-/// are changed on disk. @warning By default, this listener may be called on
-/// arbitrary threads. If your code isn't prepared for that, you may want to use
-/// \ref CBLDatabase_BufferNotifications so that listeners will be called in a
-/// safe context. @param context An arbitrary value given when the callback was
-/// registered. @param change The collection change information.
 typedef CBLCollectionChangeListener
     = ffi.Pointer<ffi.NativeFunction<CBLCollectionChangeListenerFunction>>;
 typedef NativeCBLCollection_AddChangeListener
@@ -8253,16 +6655,9 @@ typedef DartCBLCollection_AddChangeListener
         CBLCollectionChangeListener listener,
         ffi.Pointer<ffi.Void> context);
 
-/// \name Document listeners @{ A document change listener lets you detect
-/// changes made to a specific document after they are persisted to the
-/// collection. @note If there are multiple CBLCollection instances on the same
-/// database file, each one's document listeners will be notified of changes
-/// made by other collection instances.
 final class CBLDocumentChange extends ffi.Struct {
-  /// < The collection that changed.
   external ffi.Pointer<CBLCollection> collection;
 
-  /// <The document's ID.
   external FLString docID;
 }
 
@@ -8270,13 +6665,6 @@ typedef CBLCollectionDocumentChangeListenerFunction = ffi.Void Function(
     ffi.Pointer<ffi.Void> context, ffi.Pointer<CBLDocumentChange> change);
 typedef DartCBLCollectionDocumentChangeListenerFunction = void Function(
     ffi.Pointer<ffi.Void> context, ffi.Pointer<CBLDocumentChange> change);
-
-/// A document change listener callback, invoked after a specific document is
-/// changed on disk. @warning By default, this listener may be called on
-/// arbitrary threads. If your code isn't prepared for that, you may want to use
-/// \ref CBLDatabase_BufferNotifications so that listeners will be called in a
-/// safe context. @param context An arbitrary value given when the callback was
-/// registered. @param change The document change info.
 typedef CBLCollectionDocumentChangeListener = ffi
     .Pointer<ffi.NativeFunction<CBLCollectionDocumentChangeListenerFunction>>;
 typedef NativeCBLCollection_AddDocumentChangeListener
@@ -8295,43 +6683,24 @@ typedef NativeCBL_EnableVectorSearch = ffi.Bool Function(
     FLString path, ffi.Pointer<CBLError> outError);
 typedef DartCBL_EnableVectorSearch = bool Function(
     FLString path, ffi.Pointer<CBLError> outError);
-
-/// Database encryption algorithms (available only in the Enterprise Edition).
 typedef CBLEncryptionAlgorithm = ffi.Uint32;
 typedef DartCBLEncryptionAlgorithm = int;
-
-/// Encryption key sizes (in bytes).
 typedef CBLEncryptionKeySize = ffi.Uint64;
 typedef DartCBLEncryptionKeySize = int;
 
-/// Encryption key specified in a \ref CBLDatabaseConfiguration.
 final class CBLEncryptionKey extends ffi.Struct {
-  /// < Encryption algorithm
   @CBLEncryptionAlgorithm()
   external int algorithm;
 
-  /// < Raw key data
   @ffi.Array.multi([32])
   external ffi.Array<ffi.Uint8> bytes;
 }
 
-/// Database configuration options.
 final class CBLDatabaseConfiguration extends ffi.Struct {
-  /// < The parent directory of the database
   external FLString directory;
 
-  /// < The database's encryption key (if any)
   external CBLEncryptionKey encryptionKey;
 
-  /// As Couchbase Lite normally configures its databases, There is a very small
-  /// (though non-zero) chance that a power failure at just the wrong time could
-  /// cause the most recently committed transaction's changes to be lost. This
-  /// would cause the database to appear as it did immediately before that
-  /// transaction.
-  ///
-  /// Setting this mode true ensures that an operating system crash or power
-  /// failure will not cause the loss of any data. FULL synchronous is very safe
-  /// but it is also dramatically slower.
   @ffi.Bool()
   external bool fullSync;
 }
@@ -8400,8 +6769,6 @@ typedef DartCBLDatabase_ChangeEncryptionKey = bool Function(
     ffi.Pointer<CBLDatabase> arg0,
     ffi.Pointer<CBLEncryptionKey> newKey,
     ffi.Pointer<CBLError> outError);
-
-/// Maintenance Type used when performing database maintenance.
 typedef CBLMaintenanceType = ffi.Uint32;
 typedef DartCBLMaintenanceType = int;
 typedef NativeCBLDatabase_PerformMaintenance = ffi.Bool Function(
@@ -8463,17 +6830,6 @@ typedef DartCBLDatabaseChangeListenerFunction = void Function(
     ffi.Pointer<CBLDatabase> db,
     int numDocs,
     ffi.Pointer<FLString> docIDs);
-
-/// A default collection change listener callback, invoked after one or more
-/// documents in the default collection are changed on disk. @warning By
-/// default, this listener may be called on arbitrary threads. If your code
-/// isn't prepared for that, you may want to use \ref
-/// CBLDatabase_BufferNotifications so that listeners will be called in a safe
-/// context. @warning <b>Deprecated :</b> CBLCollectionChangeListener instead.
-/// @param context An arbitrary value given when the callback was registered.
-/// @param db The database that changed. @param numDocs The number of documents
-/// that changed (size of the `docIDs` array) @param docIDs The IDs of the
-/// documents that changed, as a C array of `numDocs` C strings.
 typedef CBLDatabaseChangeListener
     = ffi.Pointer<ffi.NativeFunction<CBLDatabaseChangeListenerFunction>>;
 typedef NativeCBLDatabase_AddChangeListener
@@ -8486,16 +6842,6 @@ typedef CBLNotificationsReadyCallbackFunction = ffi.Void Function(
     ffi.Pointer<ffi.Void> context, ffi.Pointer<CBLDatabase> db);
 typedef DartCBLNotificationsReadyCallbackFunction = void Function(
     ffi.Pointer<ffi.Void> context, ffi.Pointer<CBLDatabase> db);
-
-/// Callback indicating that the database (or an object belonging to it) is
-/// ready to call one or more listeners. You should call \ref
-/// CBLDatabase*SendNotifications at your earliest convenience, in the context
-/// (thread, dispatch queue, etc.) you want them to run. @note This callback is
-/// called \_only once* until the next time \ref CBLDatabase_SendNotifications
-/// is called. If you don't respond by (sooner or later) calling that function,
-/// you will not be informed that any listeners are ready. @warning This can be
-/// called from arbitrary threads. It should do as little work as possible, just
-/// scheduling a future call to \ref CBLDatabase_SendNotifications.
 typedef CBLNotificationsReadyCallback
     = ffi.Pointer<ffi.NativeFunction<CBLNotificationsReadyCallbackFunction>>;
 typedef NativeCBLDatabase_BufferNotifications = ffi.Void Function(
@@ -8538,12 +6884,8 @@ typedef DartCBLAuth_CreateSession = ffi.Pointer<CBLAuthenticator> Function(
 typedef NativeCBLAuth_Free = ffi.Void Function(
     ffi.Pointer<CBLAuthenticator> arg0);
 typedef DartCBLAuth_Free = void Function(ffi.Pointer<CBLAuthenticator> arg0);
-
-/// Direction of replication: push, pull, or both.
 typedef CBLReplicatorType = ffi.Uint8;
 typedef DartCBLReplicatorType = int;
-
-/// Flags describing a replicated document.
 typedef CBLDocumentFlags = ffi.UnsignedInt;
 typedef DartCBLDocumentFlags = int;
 typedef CBLReplicationFilterFunction = ffi.Bool Function(
@@ -8554,15 +6896,6 @@ typedef DartCBLReplicationFilterFunction = bool Function(
     ffi.Pointer<ffi.Void> context,
     ffi.Pointer<CBLDocument> document,
     DartCBLDocumentFlags flags);
-
-/// A callback that can decide whether a particular document should be pushed or
-/// pulled. @warning This callback will be called on a background thread managed
-/// by the replicator. It must pay attention to thread-safety. It should not
-/// take a long time to return, or it will slow down the replicator. @param
-/// context The `context` field of the \ref CBLReplicatorConfiguration. @param
-/// document The document in question. @param flags Indicates whether the
-/// document was deleted or removed. @return True if the document should be
-/// replicated, false to skip it.
 typedef CBLReplicationFilter
     = ffi.Pointer<ffi.NativeFunction<CBLReplicationFilterFunction>>;
 typedef CBLConflictResolverFunction = ffi.Pointer<CBLDocument> Function(
@@ -8570,52 +6903,22 @@ typedef CBLConflictResolverFunction = ffi.Pointer<CBLDocument> Function(
     FLString documentID,
     ffi.Pointer<CBLDocument> localDocument,
     ffi.Pointer<CBLDocument> remoteDocument);
-
-/// Conflict-resolution callback for use in replications. This callback will be
-/// invoked when the replicator finds a newer server-side revision of a document
-/// that also has local changes. The local and remote changes must be resolved
-/// before the document can be pushed to the server. @note Any new CBLBlob
-/// objects set to the resolved document returned by the callback must not be
-/// released. They need to be retained for installation while the resolved
-/// document is being saved into the database, and the replicator will be
-/// responsible for releasing them after they are installed. @warning This
-/// callback will be called on a background thread managed by the replicator. It
-/// must pay attention to thread-safety. However, unlike a filter callback, it
-/// does not need to return quickly. If it needs to prompt for user input,
-/// that's OK. @param context The `context` field of the \ref
-/// CBLReplicatorConfiguration. @param documentID The ID of the conflicted
-/// document. @param localDocument The current revision of the document in the
-/// local database, or NULL if the local document has been deleted. @param
-/// remoteDocument The revision of the document found on the server, or NULL if
-/// the document has been deleted on the server. @return The resolved document
-/// to save locally (and push, if the replicator is pushing.) This can be the
-/// same as \p localDocument or \p remoteDocument, or you can create a mutable
-/// copy of either one and modify it appropriately. Or return NULL if the
-/// resolution is to delete the document.
 typedef CBLConflictResolver
     = ffi.Pointer<ffi.NativeFunction<CBLConflictResolverFunction>>;
-
-/// Types of proxy servers, for CBLProxySettings.
 typedef CBLProxyType = ffi.Uint8;
 typedef DartCBLProxyType = int;
 
-/// Proxy settings for the replicator.
 final class CBLProxySettings extends ffi.Struct {
-  /// < Type of proxy
   @CBLProxyType()
   external int type;
 
-  /// < Proxy server hostname or IP address
   external FLString hostname;
 
-  /// < Proxy server port
   @ffi.Uint16()
   external int port;
 
-  /// < Username for proxy auth (optional)
   external FLString username;
 
-  /// < Password for proxy auth
   external FLString password;
 }
 
@@ -8628,34 +6931,6 @@ typedef CBLPropertyEncryptorFunction = FLSliceResult Function(
     ffi.Pointer<FLStringResult> algorithm,
     ffi.Pointer<FLStringResult> kid,
     ffi.Pointer<CBLError> error);
-
-/// Callback that encrypts \ref CBLEncryptable properties in the documents of
-/// the default collection pushed by the replicator. The callback returns
-/// encrypted data as a FLSliceResult object, and the replicator will
-/// responsible for releasing the returned FLSliceResult object.
-///
-/// If an error occurred during encryption, return a null \ref FLSliceResult
-/// with an error set to the out error parameter of the callback. There are two
-/// errors that are supported by the callback :
-///
-/// 1. kCBLDomain / kCBLErrorCrypto : Permanent Crypto Error. When this error is
-///    set, the document will fail to replicate, and the document will not be
-///    synced again unless the document is updated, or the replicator is reset.
-///
-/// 2. kCBLWebSocketDomain / 503 : Service Unavailable Error. This error is for
-///    mostly for a case such as when a crypto service is temporarily
-///    unavailable during encryption. When this error is set, the replicator
-///    will go into the offline state and will retry again according to the
-///    replicator retry logic. As a result, the document will be retried to
-///    replicate again, and the encryption callback will be called again to
-///    encrypt the properties of the document.
-///
-/// @note If an error besides the two errors above is set to the out error
-/// parameter of the callback, or only a null \ref FLSliceResult object is
-/// returned without setting an error, the document will be failed to replicate
-/// as the kCBLDomain / kCBLErrorCrypto error is sepecified. @note A null \ref
-/// FLSliceResult can be created by calling FLSliceResult_CreateWith(nullptr,
-/// 0). @warning <b>Deprecated :</b> Use CBLDocumentPropertyEncryptor instead.
 typedef CBLPropertyEncryptor
     = ffi.Pointer<ffi.NativeFunction<CBLPropertyEncryptorFunction>>;
 typedef CBLPropertyDecryptorFunction = FLSliceResult Function(
@@ -8667,37 +6942,6 @@ typedef CBLPropertyDecryptorFunction = FLSliceResult Function(
     FLString algorithm,
     FLString kid,
     ffi.Pointer<CBLError> error);
-
-/// Callback that decrypts encrypted \ref CBLEncryptable properties in documents
-/// of the default collection pulled by the replicator. The callback returns
-/// decrypted data as a FLSliceResult object, and the replicator will
-/// responsible for releasing the returned FLSliceResult object.
-///
-/// If an error occurred during decryption, return a null \ref FLSliceResult
-/// with an error set to the out error parameter of the callback. There are two
-/// errors that are supported by the callback :
-///
-/// 1. kCBLDomain / kCBLErrorCrypto : Permanent Crypto Error. When this error is
-///    set, the document will fail to replicate, and the document will not be
-///    synced again unless the document is updated, or the replicator is reset.
-///
-/// 2. kCBLWebSocketDomain / 503 : Service Unavailable Error. This error is for
-///    mostly for a case such as when a crypto service is temporarily
-///    unavailable during decryption. When this error is set, the replicator
-///    will go into the offline state and will retry again according to the
-///    replicator retry logic. As a result, the document will be retried to
-///    replicate again, and the decryption callback will be called again to
-///    decrypt the properties of the document.
-///
-/// If the decryption should be skipped to retain the encrypted data as-is,
-/// return a null \ref FLSliceResult object without setting an error set to the
-/// out error parameter.
-///
-/// @note If an error besides the two errors above is set to the out error
-/// parameter of the callback, the document will be failed to replicate as
-/// getting the kCBLDomain / kCBLErrorCrypto error. @note A null \ref
-/// FLSliceResult can be created by calling FLSliceResult_CreateWith(nullptr,
-/// 0). @warning <b>Deprecated :</b> Use CBLDocumentPropertyDecryptor instead.
 typedef CBLPropertyDecryptor
     = ffi.Pointer<ffi.NativeFunction<CBLPropertyDecryptorFunction>>;
 typedef CBLDocumentPropertyEncryptorFunction = FLSliceResult Function(
@@ -8711,34 +6955,6 @@ typedef CBLDocumentPropertyEncryptorFunction = FLSliceResult Function(
     ffi.Pointer<FLStringResult> algorithm,
     ffi.Pointer<FLStringResult> kid,
     ffi.Pointer<CBLError> error);
-
-/// Callback that encrypts \ref CBLEncryptable properties in the documents
-/// pushed by the replicator. The callback returns encrypted data as a
-/// FLSliceResult object, and the replicator will responsible for releasing the
-/// returned FLSliceResult object.
-///
-/// If an error occurred during encryption, return a null \ref FLSliceResult
-/// with an error set to the out error parameter of the callback. There are two
-/// errors that are supported by the callback :
-///
-/// 1. kCBLDomain / kCBLErrorCrypto : Permanent Crypto Error. When this error is
-///    set, the document will fail to replicate, and the document will not be
-///    synced again unless the document is updated, or the replicator is reset.
-///
-/// 2. kCBLWebSocketDomain / 503 : Service Unavailable Error. This error is for
-///    mostly for a case such as when a crypto service is temporarily
-///    unavailable during encryption. When this error is set, the replicator
-///    will go into the offline state and will retry again according to the
-///    replicator retry logic. As a result, the document will be retried to
-///    replicate again, and the encryption callback will be called again to
-///    encrypt the properties of the document.
-///
-/// @note If an error besides the two errors above is set to the out error
-/// parameter of the callback, or only a null \ref FLSliceResult object is
-/// returned without setting an error, the document will be failed to replicate
-/// as the kCBLDomain / kCBLErrorCrypto error is sepecified. @note A null \ref
-/// FLSliceResult can be created by calling FLSliceResult_CreateWith(nullptr,
-/// 0).
 typedef CBLDocumentPropertyEncryptor
     = ffi.Pointer<ffi.NativeFunction<CBLDocumentPropertyEncryptorFunction>>;
 typedef CBLDocumentPropertyDecryptorFunction = FLSliceResult Function(
@@ -8752,200 +6968,81 @@ typedef CBLDocumentPropertyDecryptorFunction = FLSliceResult Function(
     FLString algorithm,
     FLString kid,
     ffi.Pointer<CBLError> error);
-
-/// Callback that decrypts encrypted \ref CBLEncryptable properties in documents
-/// pulled by the replicator. The callback returns decrypted data as a
-/// FLSliceResult object, and the replicator will responsible for releasing the
-/// returned FLSliceResult object.
-///
-/// If an error occurred during decryption, return a null \ref FLSliceResult
-/// with an error set to the out error parameter of the callback. There are two
-/// errors that are supported by the callback :
-///
-/// 1. kCBLDomain / kCBLErrorCrypto : Permanent Crypto Error. When this error is
-///    set, the document will fail to replicate, and the document will not be
-///    synced again unless the document is updated, or the replicator is reset.
-///
-/// 2. kCBLWebSocketDomain / 503 : Service Unavailable Error. This error is for
-///    mostly for a case such as when a crypto service is temporarily
-///    unavailable during decryption. When this error is set, the replicator
-///    will go into the offline state and will retry again according to the
-///    replicator retry logic. As a result, the document will be retried to
-///    replicate again, and the decryption callback will be called again to
-///    decrypt the properties of the document.
-///
-/// If the decryption should be skipped to retain the encrypted data as-is,
-/// return a null \ref FLSliceResult object without setting an error set to the
-/// out error parameter.
-///
-/// @note If an error besides the two errors above is set to the out error
-/// parameter of the callback, the document will be failed to replicate as
-/// getting the kCBLDomain / kCBLErrorCrypto error. @note A null \ref
-/// FLSliceResult can be created by calling FLSliceResult_CreateWith(nullptr,
-/// 0).
 typedef CBLDocumentPropertyDecryptor
     = ffi.Pointer<ffi.NativeFunction<CBLDocumentPropertyDecryptorFunction>>;
 
-/// The collection and the configuration that can be configured specifically for
-/// the replication.
 final class CBLReplicationCollection extends ffi.Struct {
-  /// < The collection.
   external ffi.Pointer<CBLCollection> collection;
 
-  /// < Optional conflict-resolver callback
   external CBLConflictResolver conflictResolver;
 
-  /// < Optional callback to filter which docs are pushed
   external CBLReplicationFilter pushFilter;
 
-  /// < Optional callback to validate incoming docs.
   external CBLReplicationFilter pullFilter;
 
-  /// Optional set of channels to pull from. @note Channels are not supported in
-  /// Peer-to-Peer and Database-to-Database replication.
   external FLArray channels;
 
-  /// < Optional set of document IDs to replicate
   external FLArray documentIDs;
 }
 
-/// The configuration of a replicator.
 final class CBLReplicatorConfiguration extends ffi.Struct {
-  /// The database to replicate. When setting the database, ONLY the default
-  /// collection will be used for replication. (Required if collections is not
-  /// set) @warning <b>Deprecated :</b> Use collections instead.
   external ffi.Pointer<CBLDatabase> database;
 
-  /// <
   external ffi.Pointer<CBLEndpoint> endpoint;
 
-  /// Push, pull or both. The default value is \ref kCBLDefaultReplicatorType.
   @CBLReplicatorType()
   external int replicatorType;
 
-  /// Continuous replication?. The default value is \ref
-  /// kCBLDefaultReplicatorContinuous.
   @ffi.Bool()
   external bool continuous;
 
-  /// If auto purge is active, then the library will automatically purge any
-  /// documents that the replicating user loses access to via the Sync Function
-  /// on Sync Gateway. If disableAutoPurge is true, this behavior is disabled
-  /// and an access removed event will be sent to any document listeners that
-  /// are active on the replicator. The default value is \ref
-  /// kCBLDefaultReplicatorDisableAutoPurge.
-  ///
-  /// \note Auto Purge will not be performed when documentIDs filter is
-  /// specified.
   @ffi.Bool()
   external bool disableAutoPurge;
 
-  /// Max retry attempts where the initial connect to replicate counts toward
-  /// the given value. The default value is \ref
-  /// kCBLDefaultReplicatorMaxAttemptsSingleShot for a one-shot replicator and
-  /// \ref kCBLDefaultReplicatorMaxAttemptsContinuous for a continuous
-  /// replicator. Specify 1 means there will be no retry after the first
-  /// attempt.
   @ffi.UnsignedInt()
   external int maxAttempts;
 
-  /// Max wait time between retry attempts in seconds. The default value \ref
-  /// kCBLDefaultReplicatorMaxAttemptsWaitTime.
   @ffi.UnsignedInt()
   external int maxAttemptWaitTime;
 
-  /// The heartbeat interval in seconds. The default value is \ref
-  /// kCBLDefaultReplicatorHeartbeat.
   @ffi.UnsignedInt()
   external int heartbeat;
 
-  /// < Authentication credentials, if needed
   external ffi.Pointer<CBLAuthenticator> authenticator;
 
-  /// < HTTP client proxy settings
   external ffi.Pointer<CBLProxySettings> proxy;
 
-  /// < Extra HTTP headers to add to the WebSocket request
   external FLDict headers;
 
-  /// An X.509 cert (PEM or DER) to "pin" for TLS connections. The pinned cert
-  /// will be evaluated against any certs in a cert chain, and the cert chain
-  /// will be valid only if the cert chain contains the pinned cert.
   external FLSlice pinnedServerCertificate;
 
-  /// < Set of anchor certs (PEM format)
   external FLSlice trustedRootCertificates;
 
-  /// Optional set of channels to pull from when replicating with the default
-  /// collection. @note This property can only be used when setting the config
-  /// object with the database instead of collections. @note Channels are not
-  /// supported in Peer-to-Peer and Database-to-Database replication. @warning
-  /// <b>Deprecated :</b> Use CBLReplicationCollection.channels instead.
   external FLArray channels;
 
-  /// Optional set of document IDs to replicate when replicating with the
-  /// default collection. @note This property can only be used when setting the
-  /// config object with the database instead of collections. @warning
-  /// <b>Deprecated :</b> Use CBLReplicationCollection.documentIDs instead.
   external FLArray documentIDs;
 
-  /// Optional callback to filter which docs are pushed when replicating with
-  /// the default collection. @note This property can only be used when setting
-  /// the config object with the database instead of collections. @warning
-  /// <b>Deprecated :</b> Use CBLReplicationCollection.pushFilter instead.
   external CBLReplicationFilter pushFilter;
 
-  /// Optional callback to validate incoming docs when replicating with the
-  /// default collection. @note This property can only be used when setting the
-  /// config object with the database instead of collections. @warning
-  /// <b>Deprecated :</b> Use CBLReplicationCollection.pullFilter instead.
   external CBLReplicationFilter pullFilter;
 
-  /// Optional conflict-resolver callback. @note This property can only be used
-  /// when setting the config object with the database instead of collections.
-  /// @warning <b>Deprecated :</b> Use CBLReplicationCollection.conflictResolver
-  /// instead.
   external CBLConflictResolver conflictResolver;
 
-  /// < Arbitrary value that will be passed to callbacks
   external ffi.Pointer<ffi.Void> context;
 
-  /// Optional callback to encrypt \ref CBLEncryptable values of the documents
-  /// in the default collection. @note This property can only be used when
-  /// setting the config object with the database instead of collections.
-  /// @warning <b>Deprecated :</b> Use documentPropertyEncryptor instead.
   external CBLPropertyEncryptor propertyEncryptor;
 
-  /// Optional callback to decrypt encrypted \ref CBLEncryptable values of the
-  /// documents in the default collection. @note This property can only be used
-  /// when setting the config object with the database instead of collections.
-  /// @warning <b>Deprecated :</b> Use documentPropertyDecryptor instead.
   external CBLPropertyDecryptor propertyDecryptor;
 
-  /// Optional callback to encrypt \ref CBLEncryptable values.
   external CBLDocumentPropertyEncryptor documentPropertyEncryptor;
 
-  /// Optional callback to decrypt encrypted \ref CBLEncryptable values.
   external CBLDocumentPropertyDecryptor documentPropertyDecryptor;
 
-  /// The collections to replicate with the target's endpoint (Required if the
-  /// database is not set).
   external ffi.Pointer<CBLReplicationCollection> collections;
 
-  /// The number of collections (Required if the database is not set
   @ffi.Size()
   external int collectionCount;
 
-  /// The option to remove the restriction that does not allow the replicator to
-  /// save the parent-domain cookies, the cookies whose domains are the parent
-  /// domain of the remote host, from the HTTP response. For example, when the
-  /// option is set to true, the cookies whose domain are “.foo.com” returned by
-  /// “bar.foo.com” host will be permitted to save. This is only recommended if
-  /// the host issuing the cookie is well trusted.
-  ///
-  /// This option is disabled by default (see \ref
-  /// kCBLDefaultReplicatorAcceptParentCookies) which means that the
-  /// parent-domain cookies are not permitted to save by default.
   @ffi.Bool()
   external bool acceptParentDomainCookies;
 }
@@ -8975,36 +7072,23 @@ typedef NativeCBLReplicator_SetSuspended = ffi.Void Function(
     ffi.Pointer<CBLReplicator> repl, ffi.Bool suspended);
 typedef DartCBLReplicator_SetSuspended = void Function(
     ffi.Pointer<CBLReplicator> repl, bool suspended);
-
-/// The possible states a replicator can be in during its lifecycle.
 typedef CBLReplicatorActivityLevel = ffi.Uint8;
 typedef DartCBLReplicatorActivityLevel = int;
 
-/// A fractional progress value, ranging from 0.0 to 1.0 as replication
-/// progresses. The value is very approximate and may bounce around during
-/// replication; making it more accurate would require slowing down the
-/// replicator and incurring more load on the server. It's fine to use in a
-/// progress bar, though.
 final class CBLReplicatorProgress extends ffi.Struct {
-  /// <Very-approximate fractional completion, from 0.0 to 1.0
   @ffi.Float()
   external double complete;
 
-  /// < Number of documents transferred so far
   @ffi.Uint64()
   external int documentCount;
 }
 
-/// A replicator's current status.
 final class CBLReplicatorStatus extends ffi.Struct {
-  /// < Current state
   @CBLReplicatorActivityLevel()
   external int activity;
 
-  /// < Approximate fraction complete
   external CBLReplicatorProgress progress;
 
-  /// < Error, if any
   external CBLError error;
 }
 
@@ -9050,13 +7134,6 @@ typedef DartCBLReplicatorChangeListenerFunction = void Function(
     ffi.Pointer<ffi.Void> context,
     ffi.Pointer<CBLReplicator> replicator,
     ffi.Pointer<CBLReplicatorStatus> status);
-
-/// A callback that notifies you when the replicator's status changes. @note
-/// This callback will be called on a background thread managed by the
-/// replicator. It must pay attention to thread-safety. It should not take a
-/// long time to return, or it will slow down the replicator. @param context The
-/// value given when the listener was added. @param replicator The replicator.
-/// @param status The replicator's status.
 typedef CBLReplicatorChangeListener
     = ffi.Pointer<ffi.NativeFunction<CBLReplicatorChangeListenerFunction>>;
 typedef NativeCBLReplicator_AddChangeListener
@@ -9066,22 +7143,16 @@ typedef DartCBLReplicator_AddChangeListener
     = ffi.Pointer<CBLListenerToken> Function(ffi.Pointer<CBLReplicator> arg0,
         CBLReplicatorChangeListener arg1, ffi.Pointer<ffi.Void> context);
 
-/// Information about a document that's been pushed or pulled.
 final class CBLReplicatedDocument extends ffi.Struct {
-  /// < The document ID.
   external FLString ID;
 
-  /// < Indicates whether the document was deleted or removed.
   @CBLDocumentFlags()
   external int flags;
 
-  /// < If the code is nonzero, the document failed to replicate.
   external CBLError error;
 
-  /// <The scope name of the collection
   external FLString scope;
 
-  /// <The collection name.
   external FLString collection;
 }
 
@@ -9097,15 +7168,6 @@ typedef DartCBLDocumentReplicationListenerFunction = void Function(
     bool isPush,
     int numDocuments,
     ffi.Pointer<CBLReplicatedDocument> documents);
-
-/// A callback that notifies you when documents are replicated. @note This
-/// callback will be called on a background thread managed by the replicator. It
-/// must pay attention to thread-safety. It should not take a long time to
-/// return, or it will slow down the replicator. @param context The value given
-/// when the listener was added. @param replicator The replicator. @param isPush
-/// True if the document(s) were pushed, false if pulled. @param numDocuments
-/// The number of documents reported by this callback. @param documents An array
-/// with information about each document.
 typedef CBLDocumentReplicationListener
     = ffi.Pointer<ffi.NativeFunction<CBLDocumentReplicationListenerFunction>>;
 typedef NativeCBLReplicator_AddDocumentReplicationListener
@@ -9176,13 +7238,8 @@ typedef NativeFLSlot_SetEncryptableValue = ffi.Void Function(
     FLSlot slot, ffi.Pointer<CBLEncryptable> encryptable);
 typedef DartFLSlot_SetEncryptableValue = void Function(
     FLSlot slot, ffi.Pointer<CBLEncryptable> encryptable);
-
-/// Subsystems that log information.
 typedef CBLLogDomain = ffi.Uint8;
 typedef DartCBLLogDomain = int;
-
-/// Levels of log messages. Higher values are more important/severe. Each level
-/// includes the lower ones.
 typedef CBLLogLevel = ffi.Uint8;
 typedef DartCBLLogLevel = int;
 typedef NativeCBL_Log = ffi.Void Function(
@@ -9197,10 +7254,6 @@ typedef CBLLogCallbackFunction = ffi.Void Function(
     CBLLogDomain domain, CBLLogLevel level, FLString message);
 typedef DartCBLLogCallbackFunction = void Function(
     DartCBLLogDomain domain, DartCBLLogLevel level, FLString message);
-
-/// A logging callback that the application can register. @param domain The
-/// domain of the message @param level The severity level of the message. @param
-/// message The actual formatted message.
 typedef CBLLogCallback
     = ffi.Pointer<ffi.NativeFunction<CBLLogCallbackFunction>>;
 typedef NativeCBLLog_ConsoleLevel = CBLLogLevel Function();
@@ -9216,30 +7269,18 @@ typedef DartCBLLog_Callback = CBLLogCallback Function();
 typedef NativeCBLLog_SetCallback = ffi.Void Function(CBLLogCallback callback);
 typedef DartCBLLog_SetCallback = void Function(CBLLogCallback callback);
 
-/// The properties for configuring logging to files. @warning `usePlaintext`
-/// results in significantly larger log files and higher CPU usage that may slow
-/// down your app; we recommend turning it off in production.
 final class CBLLogFileConfiguration extends ffi.Struct {
-  /// < The minimum level of message to write (Required).
   @CBLLogLevel()
   external int level;
 
-  /// < The directory where log files will be created (Required).
   external FLString directory;
 
-  /// Max number of older log files to keep (in addition to current one.) The
-  /// default is \ref kCBLDefaultLogFileMaxRotateCount.
   @ffi.Uint32()
   external int maxRotateCount;
 
-  /// The size in bytes at which a file will be rotated out (best effort). The
-  /// default is \ref kCBLDefaultLogFileMaxSize.
   @ffi.Size()
   external int maxSize;
 
-  /// Whether or not to log in plaintext (as opposed to binary.) Plaintext
-  /// logging is slower and bigger. The default is \ref
-  /// kCBLDefaultLogFileUsePlaintext.
   @ffi.Bool()
   external bool usePlaintext;
 }
@@ -9252,29 +7293,14 @@ typedef NativeCBLLog_SetFileConfig = ffi.Bool Function(
 typedef DartCBLLog_SetFileConfig = bool Function(
     CBLLogFileConfiguration arg0, ffi.Pointer<CBLError> outError);
 
-/// Predictive Model
 final class CBLPredictiveModel extends ffi.Struct {
-  /// A pointer to any external data needed by the `prediction` callback, which
-  /// will receive this as its first parameter.
   external ffi.Pointer<ffi.Void> context;
 
-  /// Prediction callback, called from within a query (or document indexing) to
-  /// run the prediction. @param context The value of the CBLPredictiveModel's
-  /// `context` field. @param input The input dictionary from the query. @return
-  /// The output of the prediction function as an FLMutableDict, or NULL if
-  /// there is no output. @note The output FLMutableDict will be automatically
-  /// released after the prediction callback is called. @warning This function
-  /// must be "pure": given the same input parameters it must always produce the
-  /// same output (otherwise indexes or queries may be messed up). It MUST NOT
-  /// alter the database or any documents, nor run a query: either of those are
-  /// very likely to cause a crash.
   external ffi.Pointer<
       ffi.NativeFunction<
           FLMutableDict Function(
               ffi.Pointer<ffi.Void> context, FLDict input)>> prediction;
 
-  /// Unregistered callback, called if the model is unregistered, so it can
-  /// release resources.
   external ffi.Pointer<
           ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void> context)>>
       unregistered;
@@ -9351,16 +7377,6 @@ typedef DartCBLQueryChangeListenerFunction = void Function(
     ffi.Pointer<ffi.Void> context,
     ffi.Pointer<CBLQuery> query,
     ffi.Pointer<CBLListenerToken> token);
-
-/// A callback to be invoked after the query's results have changed. The actual
-/// result set can be obtained by calling \ref CBLQuery_CopyCurrentResults,
-/// either during the callback or at any time thereafter. @warning By default,
-/// this listener may be called on arbitrary threads. If your code isn't
-/// prepared for that, you may want to use \ref CBLDatabase_BufferNotifications
-/// so that listeners will be called in a safe context. @param context The same
-/// `context` value that you passed when adding the listener. @param query The
-/// query that triggered the listener. @param token The token for obtaining the
-/// query results by calling \ref CBLQuery_CopyCurrentResults.
 typedef CBLQueryChangeListener
     = ffi.Pointer<ffi.NativeFunction<CBLQueryChangeListenerFunction>>;
 typedef NativeCBLQuery_AddChangeListener
@@ -9475,7 +7491,6 @@ final class _FLSharedKeys extends ffi.Opaque {}
 
 typedef FLSharedKeys = ffi.Pointer<_FLSharedKeys>;
 
-/// Error codes returned from some API calls.
 enum FLError {
   kFLNoError(0),
   kFLMemoryError(1),
@@ -9510,19 +7525,8 @@ enum FLError {
       };
 }
 
-/// Specifies whether not input data is trusted to be 100% valid Fleece.
 enum FLTrust {
-  /// Input data is not trusted to be valid, and will be fully validated by the
-  /// API call.
   kFLUntrusted(0),
-
-  /// Input data is trusted to be valid. The API will perform only minimal
-  /// validation when reading it. This is faster than kFLUntrusted, but should
-  /// only be used if the data was generated by a trusted encoder and has not
-  /// been altered or corrupted. For example, this can be used to parse Fleece
-  /// data previously stored by your code in local storage. If invalid data is
-  /// read by this call, subsequent calls to Value accessor functions can crash
-  /// or return bogus results (including data from arbitrary memory locations.)
   kFLTrusted(1);
 
   final int value;
@@ -9535,8 +7539,6 @@ enum FLTrust {
       };
 }
 
-/// A point in time, expressed as milliseconds since the Unix epoch (1-1-1970
-/// midnight UTC.)
 typedef FLTimestamp = ffi.Int64;
 typedef DartFLTimestamp = int;
 typedef NativeFLTimestamp_Now = FLTimestamp Function();
@@ -9556,8 +7558,6 @@ typedef DartFLArray_AsMutable = FLMutableArray Function(FLArray arg0);
 typedef NativeFLArray_Get = FLValue Function(FLArray arg0, ffi.Uint32 index);
 typedef DartFLArray_Get = FLValue Function(FLArray arg0, int index);
 
-/// Opaque array iterator. Declare one on the stack and pass its address to
-/// `FLArrayIteratorBegin`.
 final class FLArrayIterator extends ffi.Struct {
   external ffi.Pointer<ffi.Void> _private1;
 
@@ -9599,8 +7599,6 @@ typedef DartFLDict_AsMutable = FLMutableDict Function(FLDict arg0);
 typedef NativeFLDict_Get = FLValue Function(FLDict arg0, FLSlice keyString);
 typedef DartFLDict_Get = FLValue Function(FLDict arg0, FLSlice keyString);
 
-/// Opaque dictionary iterator. Declare one on the stack, and pass its address
-/// to FLDictIterator_Begin.
 final class FLDictIterator extends ffi.Struct {
   external ffi.Pointer<ffi.Void> _private1;
 
@@ -9651,10 +7649,6 @@ typedef NativeFLDictIterator_End = ffi.Void Function(
 typedef DartFLDictIterator_End = void Function(
     ffi.Pointer<FLDictIterator> arg0);
 
-/// Opaque key for a dictionary. You are responsible for creating space for
-/// these; they can go on the stack, on the heap, inside other objects,
-/// anywhere. Be aware that the lookup operations that use these will write into
-/// the struct to store "hints" that speed up future searches.
 final class FLDictKey extends ffi.Struct {
   external FLSlice private1;
 
@@ -9706,10 +7700,8 @@ typedef NativeFLDeepIterator_Next = ffi.Bool Function(FLDeepIterator arg0);
 typedef DartFLDeepIterator_Next = bool Function(FLDeepIterator arg0);
 
 final class FLPathComponent extends ffi.Struct {
-  /// < Dict key, or kFLSliceNull if none
   external FLSlice key;
 
-  /// < Array index, only if there's no key
   @ffi.Uint32()
   external int index;
 }
@@ -9757,16 +7749,9 @@ typedef NativeFLDoc_GetAssociated = ffi.Pointer<ffi.Void> Function(
 typedef DartFLDoc_GetAssociated = ffi.Pointer<ffi.Void> Function(
     FLDoc doc, ffi.Pointer<ffi.Char> type);
 
-/// Output formats a FLEncoder can generate.
 enum FLEncoderFormat {
-  /// < Fleece encoding
   kFLEncodeFleece(0),
-
-  /// < JSON encoding
   kFLEncodeJSON(1),
-
-  /// < [JSON5](http://json5.org), an extension of JSON with a more readable
-  /// syntax
   kFLEncodeJSON5(2);
 
   final int value;
@@ -10007,33 +7992,14 @@ typedef NativeFLKeyPath_GetElement = ffi.Bool Function(
 typedef DartFLKeyPath_GetElement = bool Function(FLKeyPath arg0, int i,
     ffi.Pointer<FLSlice> outDictKey, ffi.Pointer<ffi.Int32> outArrayIndex);
 
-/// Types of Fleece values. Basically JSON, with the addition of Data (raw
-/// blob).
 enum FLValueType {
-  /// < Type of a NULL pointer, i.e. no such value, like JSON `undefined`. Also
-  /// the type of \ref kFLUndefinedValue, and of a value created by \ref
-  /// FLEncoder_WriteUndefined().
   kFLUndefined(-1),
-
-  /// < Equivalent to a JSON 'null'
   kFLNull(0),
-
-  /// < A `true` or `false` value
   kFLBoolean(1),
-
-  /// < A numeric value, either integer or floating-point
   kFLNumber(2),
-
-  /// < A string
   kFLString(3),
-
-  /// < Binary data (no JSON equivalent)
   kFLData(4),
-
-  /// < An array of values
   kFLArray(5),
-
-  /// < A mapping of strings to values (AKA "object" in JSON.)
   kFLDict(6);
 
   final int value;
@@ -10091,18 +8057,10 @@ typedef DartFLValue_Retain = FLValue Function(FLValue arg0);
 typedef NativeFLValue_Release = ffi.Void Function(FLValue arg0);
 typedef DartFLValue_Release = void Function(FLValue arg0);
 
-/// Option flags for making mutable copies of values.
 enum FLCopyFlags {
-  /// < Shallow copy. References immutables instead of copying.
   kFLDefaultCopy(0),
-
-  /// < Deep copy of mutable values
   kFLDeepCopy(1),
-
-  /// < Makes mutable copies of immutables instead of just refs.
   kFLCopyImmutables(2),
-
-  /// < Both deep-copy and copy-immutables.
   kFLDeepCopyImmutables(3);
 
   final int value;

--- a/packages/cbl/lib/src/bindings/cblite.dart
+++ b/packages/cbl/lib/src/bindings/cblite.dart
@@ -3846,13 +3846,13 @@ class cblite {
 
   FLDoc FLDoc_FromResultData(
     FLSliceResult data,
-    FLTrust arg1,
+    int arg1,
     FLSharedKeys arg2,
     FLSlice externData,
   ) {
     return _FLDoc_FromResultData(
       data,
-      arg1.value,
+      arg1,
       arg2,
       externData,
     );
@@ -3996,12 +3996,12 @@ class cblite {
   late final _FLEncoder_New = _FLEncoder_NewPtr.asFunction<DartFLEncoder_New>();
 
   FLEncoder FLEncoder_NewWithOptions(
-    FLEncoderFormat format,
+    int format,
     int reserveSize,
     bool uniqueStrings,
   ) {
     return _FLEncoder_NewWithOptions(
-      format.value,
+      format,
       reserveSize,
       uniqueStrings,
     );
@@ -4427,12 +4427,12 @@ class cblite {
   late final _FLEncoder_Finish =
       _FLEncoder_FinishPtr.asFunction<DartFLEncoder_Finish>();
 
-  FLError FLEncoder_GetError(
+  int FLEncoder_GetError(
     FLEncoder arg0,
   ) {
-    return FLError.fromValue(_FLEncoder_GetError(
+    return _FLEncoder_GetError(
       arg0,
-    ));
+    );
   }
 
   late final _FLEncoder_GetErrorPtr =
@@ -4684,12 +4684,12 @@ class cblite {
 
   set kFLUndefinedValue(FLValue value) => _kFLUndefinedValue.value = value;
 
-  FLValueType FLValue_GetType(
+  int FLValue_GetType(
     FLValue arg0,
   ) {
-    return FLValueType.fromValue(_FLValue_GetType(
+    return _FLValue_GetType(
       arg0,
-    ));
+    );
   }
 
   late final _FLValue_GetTypePtr =
@@ -4937,11 +4937,11 @@ class cblite {
 
   FLMutableArray FLArray_MutableCopy(
     FLArray arg0,
-    FLCopyFlags arg1,
+    int arg1,
   ) {
     return _FLArray_MutableCopy(
       arg0,
-      arg1.value,
+      arg1,
     );
   }
 
@@ -5092,11 +5092,11 @@ class cblite {
 
   FLMutableDict FLDict_MutableCopy(
     FLDict source,
-    FLCopyFlags arg1,
+    int arg1,
   ) {
     return _FLDict_MutableCopy(
       source,
-      arg1.value,
+      arg1,
     );
   }
 
@@ -5716,11 +5716,11 @@ class cblite {
 
   FLValue FLValue_FromData(
     FLSlice data,
-    FLTrust trust,
+    int trust,
   ) {
     return _FLValue_FromData(
       data,
-      trust.value,
+      trust,
     );
   }
 
@@ -7491,52 +7491,24 @@ final class _FLSharedKeys extends ffi.Opaque {}
 
 typedef FLSharedKeys = ffi.Pointer<_FLSharedKeys>;
 
-enum FLError {
-  kFLNoError(0),
-  kFLMemoryError(1),
-  kFLOutOfRange(2),
-  kFLInvalidData(3),
-  kFLEncodeError(4),
-  kFLJSONError(5),
-  kFLUnknownValue(6),
-  kFLInternalError(7),
-  kFLNotFound(8),
-  kFLSharedKeysStateError(9),
-  kFLPOSIXError(10),
-  kFLUnsupported(11);
-
-  final int value;
-  const FLError(this.value);
-
-  static FLError fromValue(int value) => switch (value) {
-        0 => kFLNoError,
-        1 => kFLMemoryError,
-        2 => kFLOutOfRange,
-        3 => kFLInvalidData,
-        4 => kFLEncodeError,
-        5 => kFLJSONError,
-        6 => kFLUnknownValue,
-        7 => kFLInternalError,
-        8 => kFLNotFound,
-        9 => kFLSharedKeysStateError,
-        10 => kFLPOSIXError,
-        11 => kFLUnsupported,
-        _ => throw ArgumentError("Unknown value for FLError: $value"),
-      };
+sealed class FLError {
+  static const kFLNoError = 0;
+  static const kFLMemoryError = 1;
+  static const kFLOutOfRange = 2;
+  static const kFLInvalidData = 3;
+  static const kFLEncodeError = 4;
+  static const kFLJSONError = 5;
+  static const kFLUnknownValue = 6;
+  static const kFLInternalError = 7;
+  static const kFLNotFound = 8;
+  static const kFLSharedKeysStateError = 9;
+  static const kFLPOSIXError = 10;
+  static const kFLUnsupported = 11;
 }
 
-enum FLTrust {
-  kFLUntrusted(0),
-  kFLTrusted(1);
-
-  final int value;
-  const FLTrust(this.value);
-
-  static FLTrust fromValue(int value) => switch (value) {
-        0 => kFLUntrusted,
-        1 => kFLTrusted,
-        _ => throw ArgumentError("Unknown value for FLTrust: $value"),
-      };
+sealed class FLTrust {
+  static const kFLUntrusted = 0;
+  static const kFLTrusted = 1;
 }
 
 typedef FLTimestamp = ffi.Int64;
@@ -7749,20 +7721,10 @@ typedef NativeFLDoc_GetAssociated = ffi.Pointer<ffi.Void> Function(
 typedef DartFLDoc_GetAssociated = ffi.Pointer<ffi.Void> Function(
     FLDoc doc, ffi.Pointer<ffi.Char> type);
 
-enum FLEncoderFormat {
-  kFLEncodeFleece(0),
-  kFLEncodeJSON(1),
-  kFLEncodeJSON5(2);
-
-  final int value;
-  const FLEncoderFormat(this.value);
-
-  static FLEncoderFormat fromValue(int value) => switch (value) {
-        0 => kFLEncodeFleece,
-        1 => kFLEncodeJSON,
-        2 => kFLEncodeJSON5,
-        _ => throw ArgumentError("Unknown value for FLEncoderFormat: $value"),
-      };
+sealed class FLEncoderFormat {
+  static const kFLEncodeFleece = 0;
+  static const kFLEncodeJSON = 1;
+  static const kFLEncodeJSON5 = 2;
 }
 
 typedef NativeFLEncoder_New = FLEncoder Function();
@@ -7992,30 +7954,15 @@ typedef NativeFLKeyPath_GetElement = ffi.Bool Function(
 typedef DartFLKeyPath_GetElement = bool Function(FLKeyPath arg0, int i,
     ffi.Pointer<FLSlice> outDictKey, ffi.Pointer<ffi.Int32> outArrayIndex);
 
-enum FLValueType {
-  kFLUndefined(-1),
-  kFLNull(0),
-  kFLBoolean(1),
-  kFLNumber(2),
-  kFLString(3),
-  kFLData(4),
-  kFLArray(5),
-  kFLDict(6);
-
-  final int value;
-  const FLValueType(this.value);
-
-  static FLValueType fromValue(int value) => switch (value) {
-        -1 => kFLUndefined,
-        0 => kFLNull,
-        1 => kFLBoolean,
-        2 => kFLNumber,
-        3 => kFLString,
-        4 => kFLData,
-        5 => kFLArray,
-        6 => kFLDict,
-        _ => throw ArgumentError("Unknown value for FLValueType: $value"),
-      };
+sealed class FLValueType {
+  static const kFLUndefined = -1;
+  static const kFLNull = 0;
+  static const kFLBoolean = 1;
+  static const kFLNumber = 2;
+  static const kFLString = 3;
+  static const kFLData = 4;
+  static const kFLArray = 5;
+  static const kFLDict = 6;
 }
 
 typedef NativeFLValue_GetType = ffi.Int Function(FLValue arg0);
@@ -8057,22 +8004,11 @@ typedef DartFLValue_Retain = FLValue Function(FLValue arg0);
 typedef NativeFLValue_Release = ffi.Void Function(FLValue arg0);
 typedef DartFLValue_Release = void Function(FLValue arg0);
 
-enum FLCopyFlags {
-  kFLDefaultCopy(0),
-  kFLDeepCopy(1),
-  kFLCopyImmutables(2),
-  kFLDeepCopyImmutables(3);
-
-  final int value;
-  const FLCopyFlags(this.value);
-
-  static FLCopyFlags fromValue(int value) => switch (value) {
-        0 => kFLDefaultCopy,
-        1 => kFLDeepCopy,
-        2 => kFLCopyImmutables,
-        3 => kFLDeepCopyImmutables,
-        _ => throw ArgumentError("Unknown value for FLCopyFlags: $value"),
-      };
+sealed class FLCopyFlags {
+  static const kFLDefaultCopy = 0;
+  static const kFLDeepCopy = 1;
+  static const kFLCopyImmutables = 2;
+  static const kFLDeepCopyImmutables = 3;
 }
 
 typedef NativeFLArray_MutableCopy = FLMutableArray Function(

--- a/packages/cbl/lib/src/bindings/cblitedart.dart
+++ b/packages/cbl/lib/src/bindings/cblitedart.dart
@@ -248,16 +248,16 @@ class cblitedart {
       _CBLDart_FLEncoder_WriteArrayValuePtr.asFunction<
           DartCBLDart_FLEncoder_WriteArrayValue>();
 
-  CBLDartInitializeResult CBLDart_Initialize(
+  int CBLDart_Initialize(
     ffi.Pointer<ffi.Void> dartInitializeDlData,
     ffi.Pointer<ffi.Void> cblInitContext,
     ffi.Pointer<CBLError> errorOut,
   ) {
-    return CBLDartInitializeResult.fromValue(_CBLDart_Initialize(
+    return _CBLDart_Initialize(
       dartInitializeDlData,
       cblInitContext,
       errorOut,
-    ));
+    );
   }
 
   late final _CBLDart_InitializePtr =
@@ -901,21 +901,10 @@ typedef NativeCBLDart_FLEncoder_WriteArrayValue = ffi.Bool Function(
 typedef DartCBLDart_FLEncoder_WriteArrayValue = bool Function(
     imp1.FLEncoder encoder, imp1.FLArray array, int index);
 
-enum CBLDartInitializeResult {
-  CBLDartInitializeResult_kSuccess(0),
-  CBLDartInitializeResult_kIncompatibleDartVM(1),
-  CBLDartInitializeResult_kCBLInitError(2);
-
-  final int value;
-  const CBLDartInitializeResult(this.value);
-
-  static CBLDartInitializeResult fromValue(int value) => switch (value) {
-        0 => CBLDartInitializeResult_kSuccess,
-        1 => CBLDartInitializeResult_kIncompatibleDartVM,
-        2 => CBLDartInitializeResult_kCBLInitError,
-        _ => throw ArgumentError(
-            "Unknown value for CBLDartInitializeResult: $value"),
-      };
+sealed class CBLDartInitializeResult {
+  static const CBLDartInitializeResult_kSuccess = 0;
+  static const CBLDartInitializeResult_kIncompatibleDartVM = 1;
+  static const CBLDartInitializeResult_kCBLInitError = 2;
 }
 
 typedef CBLError = imp1.CBLError;
@@ -1061,27 +1050,15 @@ typedef DartCBLDart_CBLCollection_AddChangeListener = void Function(
     ffi.Pointer<CBLCollection> collection,
     CBLDart_AsyncCallback listener);
 
-enum CBLDart_IndexType {
-  kCBLDart_IndexTypeValue(0),
-  kCBLDart_IndexTypeFullText(1),
-  kCBLDart_IndexTypeVector(2);
-
-  final int value;
-  const CBLDart_IndexType(this.value);
-
-  static CBLDart_IndexType fromValue(int value) => switch (value) {
-        0 => kCBLDart_IndexTypeValue,
-        1 => kCBLDart_IndexTypeFullText,
-        2 => kCBLDart_IndexTypeVector,
-        _ => throw ArgumentError("Unknown value for CBLDart_IndexType: $value"),
-      };
+sealed class CBLDart_IndexType {
+  static const kCBLDart_IndexTypeValue = 0;
+  static const kCBLDart_IndexTypeFullText = 1;
+  static const kCBLDart_IndexTypeVector = 2;
 }
 
 final class CBLDart_CBLIndexSpec extends ffi.Struct {
   @ffi.Uint8()
-  external int typeAsInt;
-
-  CBLDart_IndexType get type => CBLDart_IndexType.fromValue(typeAsInt);
+  external int type;
 
   @imp1.CBLQueryLanguage()
   external int expressionLanguage;

--- a/packages/cbl/lib/src/bindings/cblitedart.dart
+++ b/packages/cbl/lib/src/bindings/cblitedart.dart
@@ -248,11 +248,6 @@ class cblitedart {
       _CBLDart_FLEncoder_WriteArrayValuePtr.asFunction<
           DartCBLDart_FLEncoder_WriteArrayValue>();
 
-  /// Initializes the native libraries.
-  ///
-  /// This function can be called multiple times and is thread save. The
-  /// libraries are only initialized by the first call and subsequent calls are
-  /// NOOPs.
   CBLDartInitializeResult CBLDart_Initialize(
     ffi.Pointer<ffi.Void> dartInitializeDlData,
     ffi.Pointer<ffi.Void> cblInitContext,
@@ -807,8 +802,6 @@ final class CBLDart_LoadedDictKey extends ffi.Struct {
   external imp1.FLValue value;
 }
 
-/// A simple reference to a block of memory. Does not imply ownership. (This is
-/// equivalent to the C++ class `slice`.)
 typedef FLSlice = imp1.FLSlice;
 
 final class CBLDart_LoadedFLValue extends ffi.Struct {
@@ -908,11 +901,6 @@ typedef NativeCBLDart_FLEncoder_WriteArrayValue = ffi.Bool Function(
 typedef DartCBLDart_FLEncoder_WriteArrayValue = bool Function(
     imp1.FLEncoder encoder, imp1.FLArray array, int index);
 
-/// This is a compatibility layer to allow Dart code to use the Couchbase Lite C
-/// API. Some method signatures are incompatible with Dart's FFI capabilities.
-///
-/// This layer is also where memory management of objects from the Couchbase
-/// Lite C API is integrated with the garbage collection of Dart objects.
 enum CBLDartInitializeResult {
   CBLDartInitializeResult_kSuccess(0),
   CBLDartInitializeResult_kIncompatibleDartVM(1),
@@ -930,10 +918,6 @@ enum CBLDartInitializeResult {
       };
 }
 
-/// A struct holding information about an error. It's declared on the stack by a
-/// caller, and its address is passed to an API function. If the function's
-/// return value indicates that there was an error (usually by returning NULL or
-/// false), then the CBLError will have been filled in with the details.
 typedef CBLError = imp1.CBLError;
 typedef NativeCBLDart_Initialize = ffi.UnsignedInt Function(
     ffi.Pointer<ffi.Void> dartInitializeDlData,
@@ -947,8 +931,6 @@ typedef DartCBLDart_Initialize = int Function(
 final class _CBLDart_AsyncCallback extends ffi.Opaque {}
 
 typedef CBLDart_AsyncCallback = ffi.Pointer<_CBLDart_AsyncCallback>;
-
-/// A port is used to send or receive inter-isolate messages
 typedef Dart_Port = ffi.Int64;
 typedef DartDart_Port = int;
 typedef NativeCBLDart_AsyncCallback_New = CBLDart_AsyncCallback Function(
@@ -991,10 +973,6 @@ typedef DartCBLDart_CBLLog_SetCallback = bool Function(
 typedef NativeCBLDart_CBLLog_SetCallbackLevel = ffi.Void Function(
     imp1.CBLLogLevel level);
 typedef DartCBLDart_CBLLog_SetCallbackLevel = void Function(int level);
-
-/// The properties for configuring logging to files. @warning `usePlaintext`
-/// results in significantly larger log files and higher CPU usage that may slow
-/// down your app; we recommend turning it off in production.
 typedef CBLLogFileConfiguration = imp1.CBLLogFileConfiguration;
 typedef NativeCBLDart_CBLLog_SetFileConfig = ffi.Bool Function(
     ffi.Pointer<CBLLogFileConfiguration> config,
@@ -1041,8 +1019,6 @@ typedef DartCBLDart_CBL_CopyDatabase = bool Function(
     imp1.FLString toName,
     ffi.Pointer<CBLDart_CBLDatabaseConfiguration> config,
     ffi.Pointer<CBLError> outError);
-
-/// \defgroup database Database @{ \*/ /\*\* A connection to an open database.
 typedef CBLDatabase = imp1.CBLDatabase;
 typedef NativeCBLDart_CBLDatabase_Open = ffi.Pointer<CBLDatabase> Function(
     imp1.FLString name,
@@ -1064,9 +1040,6 @@ typedef DartCBLDart_CBLDatabase_Close = bool Function(
     ffi.Pointer<CBLDatabase> database,
     bool andDelete,
     ffi.Pointer<CBLError> errorOut);
-
-/// \defgroup collection Collection @{ \*/ /\*\* A collection, a document
-/// container.
 typedef CBLCollection = imp1.CBLCollection;
 typedef NativeCBLDart_CBLCollection_AddDocumentChangeListener
     = ffi.Void Function(
@@ -1154,13 +1127,7 @@ typedef DartCBLDart_CBLCollection_CreateIndex = bool Function(
     imp1.FLString name,
     CBLDart_CBLIndexSpec indexSpec,
     ffi.Pointer<CBLError> errorOut);
-
-/// An opaque 'cookie' representing a registered listener callback. It's
-/// returned from functions that register listeners, and used to remove a
-/// listener by calling \ref CBLListener_Remove.
 typedef CBLListenerToken = imp1.CBLListenerToken;
-
-/// \defgroup query Query @{ \*/ /\*\* A compiled database query.
 typedef CBLQuery = imp1.CBLQuery;
 typedef NativeCBLDart_CBLQuery_AddChangeListener
     = ffi.Pointer<CBLListenerToken> Function(ffi.Pointer<CBLDatabase> db,
@@ -1203,8 +1170,6 @@ typedef NativeCBLDart_PredictiveModel_Delete = ffi.Void Function(
 typedef DartCBLDart_PredictiveModel_Delete = void Function(
     CBLDart_PredictiveModel model);
 typedef FLSliceResult = imp1.FLSliceResult;
-
-/// A stream for reading a blob's content.
 typedef CBLBlobReadStream = imp1.CBLBlobReadStream;
 typedef NativeCBLDart_CBLBlobReader_Read = FLSliceResult Function(
     ffi.Pointer<CBLBlobReadStream> stream,
@@ -1229,14 +1194,8 @@ final class CBLDart_ReplicationCollection extends ffi.Struct {
   external CBLDart_AsyncCallback conflictResolver;
 }
 
-/// An opaque object representing the location of a database to replicate with.
 typedef CBLEndpoint = imp1.CBLEndpoint;
-
-/// An opaque object representing authentication credentials for a remote
-/// server.
 typedef CBLAuthenticator = imp1.CBLAuthenticator;
-
-/// Proxy settings for the replicator.
 typedef CBLProxySettings = imp1.CBLProxySettings;
 
 final class CBLDart_ReplicatorConfiguration extends ffi.Struct {
@@ -1278,8 +1237,6 @@ final class CBLDart_ReplicatorConfiguration extends ffi.Struct {
   external int collectionsCount;
 }
 
-/// \defgroup replication Replication @{ \*/ /\*\* A background task that syncs
-/// a \ref CBLDatabase with a remote server or peer.
 typedef CBLReplicator = imp1.CBLReplicator;
 typedef NativeCBLDart_CBLReplicator_Create
     = ffi.Pointer<CBLReplicator> Function(

--- a/packages/cbl/lib/src/bindings/collection.dart
+++ b/packages/cbl/lib/src/bindings/collection.dart
@@ -33,7 +33,7 @@ final class CBLIndexSpec {
     this.numProbes,
   });
 
-  final cblitedart.CBLDart_IndexType type;
+  final CBLDartIndexType type;
   final CBLQueryLanguage expressionLanguage;
   final String expressions;
 
@@ -251,18 +251,18 @@ final class CollectionBindings extends Bindings {
   Pointer<cblitedart.CBLDart_CBLIndexSpec> _createIndexSpec(CBLIndexSpec spec) {
     final result = globalArena<cblitedart.CBLDart_CBLIndexSpec>();
     final ref = result.ref
-      ..typeAsInt = spec.type.value
+      ..type = spec.type.value
       ..expressionLanguage = spec.expressionLanguage.value
       ..expressions = spec.expressions.toFLString();
 
     switch (spec.type) {
-      case cblitedart.CBLDart_IndexType.kCBLDart_IndexTypeValue:
+      case CBLDartIndexType.value$:
         break;
-      case cblitedart.CBLDart_IndexType.kCBLDart_IndexTypeFullText:
+      case CBLDartIndexType.fullText:
         ref
           ..ignoreAccents = spec.ignoreAccents!
           ..language = spec.language.toFLString();
-      case cblitedart.CBLDart_IndexType.kCBLDart_IndexTypeVector:
+      case CBLDartIndexType.vector:
         final encoding = switch (spec) {
           CBLIndexSpec(:final scalarQuantizerType?) =>
             cbl.CBLVectorEncoding_CreateScalarQuantizer(scalarQuantizerType),

--- a/packages/cbl/lib/src/bindings/fleece.dart
+++ b/packages/cbl/lib/src/bindings/fleece.dart
@@ -42,9 +42,41 @@ export 'cblitedart.dart'
 
 // === Error ===================================================================
 
+enum FLError {
+  noError(cblite.FLError.kFLNoError),
+  memoryError(cblite.FLError.kFLMemoryError),
+  outOfRange(cblite.FLError.kFLOutOfRange),
+  invalidData(cblite.FLError.kFLInvalidData),
+  encodeError(cblite.FLError.kFLEncodeError),
+  jsonError(cblite.FLError.kFLJSONError),
+  unknownValue(cblite.FLError.kFLUnknownValue),
+  internalError(cblite.FLError.kFLInternalError),
+  notFound(cblite.FLError.kFLNotFound),
+  sharedKeysStateError(cblite.FLError.kFLSharedKeysStateError),
+  posixError(cblite.FLError.kFLPOSIXError),
+  unsupported(cblite.FLError.kFLUnsupported);
+
+  const FLError(this.value);
+
+  static FLError fromValue(int value) => switch (value) {
+        cblite.FLError.kFLNoError => noError,
+        cblite.FLError.kFLMemoryError => memoryError,
+        cblite.FLError.kFLOutOfRange => outOfRange,
+        cblite.FLError.kFLInvalidData => invalidData,
+        cblite.FLError.kFLEncodeError => encodeError,
+        cblite.FLError.kFLJSONError => jsonError,
+        cblite.FLError.kFLUnknownValue => unknownValue,
+        cblite.FLError.kFLInternalError => internalError,
+        cblite.FLError.kFLNotFound => notFound,
+        _ => throw ArgumentError('Unknown value for FLError: $value'),
+      };
+
+  final int value;
+}
+
 void _checkFleeceError() {
-  final code = cblite.FLError.fromValue(globalFLErrorCode.value);
-  if (code != cblite.FLError.kFLNoError) {
+  final code = FLError.fromValue(globalFLErrorCode.value);
+  if (code != FLError.noError) {
     throw createCouchbaseLiteException(
       domain: CBLErrorDomain.fleece,
       code: code,
@@ -203,6 +235,21 @@ final class SlotBindings extends Bindings {
 
 // === Doc =====================================================================
 
+enum FLTrust {
+  untrusted(cblite.FLTrust.kFLUntrusted),
+  trusted(cblite.FLTrust.kFLTrusted);
+
+  const FLTrust(this.value);
+
+  static FLTrust fromValue(int value) => switch (value) {
+        cblite.FLTrust.kFLUntrusted => untrusted,
+        cblite.FLTrust.kFLTrusted => trusted,
+        _ => throw ArgumentError('Unknown value for FLTrust: $value'),
+      };
+
+  final int value;
+}
+
 final class DocBindings extends Bindings {
   DocBindings(super.parent);
 
@@ -210,13 +257,13 @@ final class DocBindings extends Bindings {
 
   cblite.FLDoc fromResultData(
     Data data,
-    cblite.FLTrust trust,
+    FLTrust trust,
     cblite.FLSharedKeys? sharedKeys,
   ) {
     final sliceResult = data.toSliceResult();
     return cbl.FLDoc_FromResultData(
       sliceResult.makeGlobalResult().ref,
-      trust,
+      trust.value,
       sharedKeys ?? nullptr,
       nullFLSlice.ref,
     );
@@ -247,6 +294,33 @@ final class DocBindings extends Bindings {
 
 // === Value ===================================================================
 
+enum FLValueType {
+  undefined(cblite.FLValueType.kFLUndefined),
+  null$(cblite.FLValueType.kFLNull),
+  boolean(cblite.FLValueType.kFLBoolean),
+  number(cblite.FLValueType.kFLNumber),
+  string(cblite.FLValueType.kFLString),
+  data(cblite.FLValueType.kFLData),
+  array(cblite.FLValueType.kFLArray),
+  dict(cblite.FLValueType.kFLDict);
+
+  const FLValueType(this.value);
+
+  static FLValueType fromValue(int value) => switch (value) {
+        cblite.FLValueType.kFLUndefined => undefined,
+        cblite.FLValueType.kFLNull => null$,
+        cblite.FLValueType.kFLBoolean => boolean,
+        cblite.FLValueType.kFLNumber => number,
+        cblite.FLValueType.kFLString => string,
+        cblite.FLValueType.kFLData => data,
+        cblite.FLValueType.kFLArray => array,
+        cblite.FLValueType.kFLDict => dict,
+        _ => throw ArgumentError('Unknown value for FLValueType: $value'),
+      };
+
+  final int value;
+}
+
 final class ValueBindings extends Bindings {
   ValueBindings(super.parent);
 
@@ -263,14 +337,14 @@ final class ValueBindings extends Bindings {
     _finalizer.attach(object, value.cast());
   }
 
-  cblite.FLValue? fromData(SliceResult data, cblite.FLTrust trust) =>
-      cbl.FLValue_FromData(data.makeGlobal().ref, trust).toNullable();
+  cblite.FLValue? fromData(SliceResult data, FLTrust trust) =>
+      cbl.FLValue_FromData(data.makeGlobal().ref, trust.value).toNullable();
 
   cblite.FLDoc? findDoc(cblite.FLValue value) =>
       cbl.FLValue_FindDoc(value).toNullable();
 
-  cblite.FLValueType getType(cblite.FLValue value) =>
-      cbl.FLValue_GetType(value);
+  FLValueType getType(cblite.FLValue value) =>
+      FLValueType.fromValue(cbl.FLValue_GetType(value));
 
   bool isInteger(cblite.FLValue value) => cbl.FLValue_IsInteger(value);
 
@@ -322,14 +396,33 @@ final class ArrayBindings extends Bindings {
 
 // === MutableArray ============================================================
 
+enum FLCopyFlags {
+  defaultCopy(cblite.FLCopyFlags.kFLDefaultCopy),
+  deepCopy(cblite.FLCopyFlags.kFLDeepCopy),
+  copyImmutables(cblite.FLCopyFlags.kFLCopyImmutables),
+  deepCopyImmutables(cblite.FLCopyFlags.kFLDeepCopyImmutables);
+
+  const FLCopyFlags(this.value);
+
+  static FLCopyFlags fromValue(int value) => switch (value) {
+        cblite.FLCopyFlags.kFLDefaultCopy => defaultCopy,
+        cblite.FLCopyFlags.kFLDeepCopy => deepCopy,
+        cblite.FLCopyFlags.kFLCopyImmutables => copyImmutables,
+        cblite.FLCopyFlags.kFLDeepCopyImmutables => deepCopyImmutables,
+        _ => throw ArgumentError('Unknown value for FLCopyFlags: $value'),
+      };
+
+  final int value;
+}
+
 final class MutableArrayBindings extends Bindings {
   MutableArrayBindings(super.parent);
 
   cblite.FLMutableArray mutableCopy(
     cblite.FLArray array,
-    cblite.FLCopyFlags flags,
+    FLCopyFlags flags,
   ) =>
-      cbl.FLArray_MutableCopy(array, flags);
+      cbl.FLArray_MutableCopy(array, flags.value);
 
   cblite.FLMutableArray create() => cbl.FLMutableArray_New();
 
@@ -414,9 +507,9 @@ final class MutableDictBindings extends Bindings {
 
   cblite.FLMutableDict mutableCopy(
     cblite.FLDict source,
-    cblite.FLCopyFlags flags,
+    FLCopyFlags flags,
   ) =>
-      cbl.FLDict_MutableCopy(source, flags);
+      cbl.FLDict_MutableCopy(source, flags.value);
 
   cblite.FLMutableDict create() => cbl.FLMutableDict_New();
 
@@ -467,7 +560,7 @@ String decodeFLString(Pointer<Void> buf, int size) =>
 
 // ignore: camel_case_extensions
 extension CBLDart_LoadedFLValueExt on cblitedart.CBLDart_LoadedFLValue {
-  cblite.FLValueType get typeEnum => cblite.FLValueType.fromValue(type);
+  FLValueType get typeEnum => FLValueType.fromValue(type);
 }
 
 final class FleeceDecoderBindings extends Bindings {
@@ -562,6 +655,23 @@ final class FleeceDecoderBindings extends Bindings {
 
 // === Encoder =================================================================
 
+enum FLEncoderFormat {
+  fleece(cblite.FLEncoderFormat.kFLEncodeFleece),
+  json(cblite.FLEncoderFormat.kFLEncodeJSON),
+  json5(cblite.FLEncoderFormat.kFLEncodeJSON5);
+
+  const FLEncoderFormat(this.value);
+
+  static FLEncoderFormat fromValue(int value) => switch (value) {
+        cblite.FLEncoderFormat.kFLEncodeFleece => fleece,
+        cblite.FLEncoderFormat.kFLEncodeJSON => json,
+        cblite.FLEncoderFormat.kFLEncodeJSON5 => json5,
+        _ => throw ArgumentError('Unknown value for FLEncoderFormat: $value'),
+      };
+
+  final int value;
+}
+
 final class FleeceEncoderBindings extends Bindings {
   FleeceEncoderBindings(super.parent);
 
@@ -572,11 +682,11 @@ final class FleeceEncoderBindings extends Bindings {
   }
 
   cblite.FLEncoder create({
-    required cblite.FLEncoderFormat format,
+    required FLEncoderFormat format,
     required int reserveSize,
     required bool uniqueStrings,
   }) =>
-      cbl.FLEncoder_NewWithOptions(format, reserveSize, uniqueStrings);
+      cbl.FLEncoder_NewWithOptions(format.value, reserveSize, uniqueStrings);
 
   void setSharedKeys(
     cblite.FLEncoder encoder,
@@ -683,8 +793,8 @@ final class FleeceEncoderBindings extends Bindings {
           .let(SliceResult.fromFLSliceResult)
           ?.toData();
 
-  cblite.FLError _getError(cblite.FLEncoder encoder) =>
-      cbl.FLEncoder_GetError(encoder);
+  FLError _getError(cblite.FLEncoder encoder) =>
+      FLError.fromValue(cbl.FLEncoder_GetError(encoder));
 
   String _getErrorMessage(cblite.FLEncoder encoder) =>
       cbl.FLEncoder_GetErrorMessage(encoder).cast<Utf8>().toDartStringAndFree();
@@ -695,7 +805,7 @@ final class FleeceEncoderBindings extends Bindings {
 
     if (mayHaveError) {
       final errorCode = _getError(encoder);
-      if (errorCode == cblite.FLError.kFLNoError) {
+      if (errorCode == FLError.noError) {
         return result;
       }
 

--- a/packages/cbl/lib/src/bindings/query.dart
+++ b/packages/cbl/lib/src/bindings/query.dart
@@ -35,6 +35,23 @@ enum CBLQueryLanguage {
   final int value;
 }
 
+enum CBLDartIndexType {
+  value$(cblitedart.CBLDart_IndexType.kCBLDart_IndexTypeValue),
+  fullText(cblitedart.CBLDart_IndexType.kCBLDart_IndexTypeFullText),
+  vector(cblitedart.CBLDart_IndexType.kCBLDart_IndexTypeVector);
+
+  const CBLDartIndexType(this.value);
+
+  static CBLDartIndexType fromValue(int value) => switch (value) {
+        cblitedart.CBLDart_IndexType.kCBLDart_IndexTypeValue => value$,
+        cblitedart.CBLDart_IndexType.kCBLDart_IndexTypeFullText => fullText,
+        cblitedart.CBLDart_IndexType.kCBLDart_IndexTypeVector => vector,
+        _ => throw ArgumentError('Unknown value for CBLDart_IndexType: $value'),
+      };
+
+  final int value;
+}
+
 final class QueryBindings extends Bindings {
   QueryBindings(super.parent);
 

--- a/packages/cbl/lib/src/document/array.dart
+++ b/packages/cbl/lib/src/document/array.dart
@@ -401,7 +401,7 @@ final class ArrayImpl
 
   @override
   String toJson() {
-    final encoder = FleeceEncoder(format: FLEncoderFormat.kFLEncodeJSON);
+    final encoder = FleeceEncoder(format: FLEncoderFormat.json);
     final done = encodeTo(encoder);
     assert(done is! Future);
     return encoder.finish().toDartString();

--- a/packages/cbl/lib/src/document/blob.dart
+++ b/packages/cbl/lib/src/document/blob.dart
@@ -236,7 +236,7 @@ final class BlobImpl implements Blob, FleeceEncodable, CblConversions {
 
   @override
   String toJson() {
-    final encoder = FleeceEncoder(format: FLEncoderFormat.kFLEncodeJSON);
+    final encoder = FleeceEncoder(format: FLEncoderFormat.json);
     final done = encodeTo(encoder);
     assert(done is! Future);
     return encoder.finish().toDartString();

--- a/packages/cbl/lib/src/document/common.dart
+++ b/packages/cbl/lib/src/document/common.dart
@@ -164,7 +164,7 @@ final class CblMDelegate extends MDelegate {
 
     final flValue = globalLoadedFLValue.ref;
     switch (FLValueType.fromValue(flValue.type)) {
-      case FLValueType.kFLUndefined:
+      case FLValueType.undefined:
         // `undefined` is a somewhat unusual value to be found in a Fleece
         // collection, since it is not JSON. It cannot be encoded to Fleece or
         // JSON, but is used by some APIs to signal a special condition.
@@ -174,24 +174,24 @@ final class CblMDelegate extends MDelegate {
         // would be a breaking change to start returning something other than
         // `null`.
         return null;
-      case FLValueType.kFLNull:
+      case FLValueType.null$:
         return null;
-      case FLValueType.kFLBoolean:
+      case FLValueType.boolean:
         return flValue.asBool;
-      case FLValueType.kFLNumber:
+      case FLValueType.number:
         return flValue.isInteger ? flValue.asInt : flValue.asDouble;
-      case FLValueType.kFLString:
+      case FLValueType.string:
         return parent.context.sharedStringsTable.decode(StringSource.value);
-      case FLValueType.kFLData:
+      case FLValueType.data:
         return flValue.asData.toData()?.toTypedList();
-      case FLValueType.kFLArray:
+      case FLValueType.array:
         final array = MArray.asChild(value, parent, flValue.collectionSize);
         if (parent.hasMutableChildren) {
           return MutableArrayImpl(array);
         } else {
           return ArrayImpl(array);
         }
-      case FLValueType.kFLDict:
+      case FLValueType.dict:
         // ignore: omit_local_variable_types
         final FLDict flDict = flValue.value.cast();
 
@@ -238,7 +238,7 @@ bool valueWouldChange(
   if (flValue != null) {
     final valueType = _valueBinds.getType(flValue);
     cblReachabilityFence(container.context);
-    if (valueType == FLValueType.kFLArray || valueType == FLValueType.kFLDict) {
+    if (valueType == FLValueType.array || valueType == FLValueType.dict) {
       return true;
     }
   }

--- a/packages/cbl/lib/src/document/dictionary.dart
+++ b/packages/cbl/lib/src/document/dictionary.dart
@@ -247,7 +247,7 @@ final class DictionaryImpl
 
   @override
   String toJson() {
-    final encoder = FleeceEncoder(format: FLEncoderFormat.kFLEncodeJSON);
+    final encoder = FleeceEncoder(format: FLEncoderFormat.json);
     final done = encodeTo(encoder);
     assert(done is! Future);
     return encoder.finish().toDartString();

--- a/packages/cbl/lib/src/document/document.dart
+++ b/packages/cbl/lib/src/document/document.dart
@@ -138,7 +138,7 @@ final class NewDocumentDelegate extends DocumentDelegate {
       return MRoot.fromContext(
         DocumentMContext(
           document,
-          data: Doc.fromResultData(properties.toFleece(), FLTrust.kFLTrusted),
+          data: Doc.fromResultData(properties.toFleece(), FLTrust.trusted),
         ),
         isMutable: isMutable,
       );

--- a/packages/cbl/lib/src/document/ffi_document.dart
+++ b/packages/cbl/lib/src/document/ffi_document.dart
@@ -70,7 +70,7 @@ final class FfiDocumentDelegate implements DocumentDelegate, Finalizable {
   }
 
   void _writeEncodedProperties(EncodedData value) {
-    final doc = fl.Doc.fromResultData(value.toFleece(), FLTrust.kFLTrusted);
+    final doc = fl.Doc.fromResultData(value.toFleece(), FLTrust.trusted);
     final dict = fl.MutableDict.mutableCopy(doc.root.asDict!);
     _mutableDocumentBindings.setProperties(pointer.cast(), dict.pointer.cast());
   }

--- a/packages/cbl/lib/src/document/proxy_document.dart
+++ b/packages/cbl/lib/src/document/proxy_document.dart
@@ -66,7 +66,7 @@ final class ProxyDocumentDelegate
     return MRoot.fromContext(
       DocumentMContext(
         document,
-        data: Doc.fromResultData(properties!.toFleece(), FLTrust.kFLTrusted),
+        data: Doc.fromResultData(properties!.toFleece(), FLTrust.trusted),
       ),
       isMutable: isMutable,
     );

--- a/packages/cbl/lib/src/fleece/containers.dart
+++ b/packages/cbl/lib/src/fleece/containers.dart
@@ -361,15 +361,15 @@ final class MutableArray extends Array {
   /// Creates a new [MutableArray] that's a copy of the source [Array].
   ///
   /// Copying an immutable Array is very cheap (only one small allocation)
-  /// unless the [FLCopyFlags.kFLCopyImmutables] is set.
+  /// unless the [FLCopyFlags.copyImmutables] is set.
   ///
   /// Copying a mutable Array is cheap if it's a shallow copy, but if
-  /// [FLCopyFlags.kFLDeepCopy] is true, nested mutable Arrays and [Dict]s are
-  /// also copied, recursively; if [FLCopyFlags.kFLDeepCopyImmutables] is set,
-  /// immutable values are also copied.
+  /// [FLCopyFlags.deepCopy] is true, nested mutable Arrays and [Dict]s are also
+  /// copied, recursively; if [FLCopyFlags.deepCopyImmutables] is set, immutable
+  /// values are also copied.
   factory MutableArray.mutableCopy(
     Array source, {
-    FLCopyFlags flags = FLCopyFlags.kFLDefaultCopy,
+    FLCopyFlags flags = FLCopyFlags.defaultCopy,
   }) =>
       MutableArray.fromPointer(
         _bindings.mutableCopy(source.pointer.cast(), flags),
@@ -572,15 +572,15 @@ final class MutableDict extends Dict {
   /// Creates a new [MutableDict] that's a copy of the source [Dict].
   ///
   /// Copying an immutable Array is very cheap (only one small allocation)
-  /// unless the [FLCopyFlags.kFLCopyImmutables] is set.
+  /// unless the [FLCopyFlags.copyImmutables] is set.
   ///
   /// Copying a mutable Array is cheap if it's a shallow copy, but if
-  /// [FLCopyFlags.kFLDeepCopy] is true, nested mutable Arrays and [Dict]s are
-  /// also copied, recursively; if [FLCopyFlags.kFLDeepCopyImmutables] is set,
-  /// immutable values are also copied.
+  /// [FLCopyFlags.deepCopy] is true, nested mutable Arrays and [Dict]s are also
+  /// copied, recursively; if [FLCopyFlags.deepCopyImmutables] is set, immutable
+  /// values are also copied.
   factory MutableDict.mutableCopy(
     Dict source, {
-    FLCopyFlags flags = FLCopyFlags.kFLDefaultCopy,
+    FLCopyFlags flags = FLCopyFlags.defaultCopy,
   }) =>
       MutableDict.fromPointer(
         _bindings.mutableCopy(source.pointer.cast(), flags),

--- a/packages/cbl/lib/src/fleece/decoder.dart
+++ b/packages/cbl/lib/src/fleece/decoder.dart
@@ -250,7 +250,7 @@ final class ArrayIterator implements Iterator<Null>, Finalizable {
 final class FleeceDecoder extends Converter<Data, Object?> {
   /// Creates a decoder for converting Fleece data into Dart objects.
   const FleeceDecoder({
-    this.trust = FLTrust.kFLUntrusted,
+    this.trust = FLTrust.untrusted,
     this.sharedKeys,
     this.sharedKeysTable,
     this.sharedStringsTable,
@@ -293,7 +293,7 @@ final class FleeceDecoder extends Converter<Data, Object?> {
 class RecursiveFleeceDecoder extends Converter<Data, Object?> {
   @Deprecated('Use FleeceDecoder instead.')
   RecursiveFleeceDecoder({
-    this.trust = FLTrust.kFLUntrusted,
+    this.trust = FLTrust.untrusted,
     this.sharedKeys,
     SharedKeysTable? sharedKeysTable,
     this.sharedStringsTable,
@@ -323,26 +323,26 @@ class RecursiveFleeceDecoder extends Converter<Data, Object?> {
   Object? _decodeGlobalLoadedValue(SharedStringsTable sharedStringsTable) {
     final value = globalLoadedFLValue.ref;
     switch (FLValueType.fromValue(value.type)) {
-      case FLValueType.kFLUndefined:
+      case FLValueType.undefined:
         _throwUndefinedDartRepresentation();
-      case FLValueType.kFLNull:
+      case FLValueType.null$:
         return null;
-      case FLValueType.kFLBoolean:
+      case FLValueType.boolean:
         return value.asBool;
-      case FLValueType.kFLNumber:
+      case FLValueType.number:
         return value.isInteger ? value.asInt : value.asDouble;
-      case FLValueType.kFLString:
+      case FLValueType.string:
         return sharedStringsTable.decode(StringSource.value);
-      case FLValueType.kFLData:
+      case FLValueType.data:
         return value.asData.toData()?.toTypedList();
-      case FLValueType.kFLArray:
+      case FLValueType.array:
         // ignore: omit_local_variable_types
         final FLArray array = value.value.cast();
         return List<Object?>.generate(value.collectionSize, (index) {
           _decoderBinds.getLoadedValueFromArray(array, index);
           return _decodeGlobalLoadedValue(sharedStringsTable);
         });
-      case FLValueType.kFLDict:
+      case FLValueType.dict:
         // ignore: omit_local_variable_types
         final FLDict dict = value.value.cast();
         final iterator = DictIterator(
@@ -416,41 +416,41 @@ final class _FleeceListenerDecoder {
         }
 
         switch (FLValueType.fromValue(value.type)) {
-          case FLValueType.kFLUndefined:
+          case FLValueType.undefined:
             _listener.handleUndefined();
             _currentLoader.handleValue();
             break;
-          case FLValueType.kFLNull:
+          case FLValueType.null$:
             _listener.handleNull();
             _currentLoader.handleValue();
             break;
-          case FLValueType.kFLBoolean:
+          case FLValueType.boolean:
             _listener.handleBool(value.asBool);
             _currentLoader.handleValue();
             break;
-          case FLValueType.kFLNumber:
+          case FLValueType.number:
             _listener
                 .handleNumber(value.isInteger ? value.asInt : value.asDouble);
             _currentLoader.handleValue();
             break;
-          case FLValueType.kFLString:
+          case FLValueType.string:
             _listener.handleString(
               _sharedStringsTable.decode(StringSource.value),
             );
             _currentLoader.handleValue();
             break;
-          case FLValueType.kFLData:
+          case FLValueType.data:
             _listener.handleData(value.asData.toData()!.toTypedList());
             _currentLoader.handleValue();
             break;
-          case FLValueType.kFLArray:
+          case FLValueType.array:
             _currentLoader = _ArrayIndexLoader(
               value.value.cast(),
               value.collectionSize,
               _listener,
             )..parent = _currentLoader;
             break;
-          case FLValueType.kFLDict:
+          case FLValueType.dict:
             _currentLoader = _DictIteratorLoader(
               value.value.cast(),
               _listener,

--- a/packages/cbl/lib/src/fleece/encoder.dart
+++ b/packages/cbl/lib/src/fleece/encoder.dart
@@ -18,7 +18,7 @@ final _bindings = CBLBindings.instance.fleece.encoder;
 final class FleeceEncoder implements Finalizable {
   /// Creates an encoder, which generates encoded Fleece or JSON data.
   FleeceEncoder({
-    this.format = FLEncoderFormat.kFLEncodeFleece,
+    this.format = FLEncoderFormat.fleece,
     this.reserveSize = 256,
     this.uniqueStrings = true,
   }) : _pointer = _bindings.create(
@@ -33,7 +33,7 @@ final class FleeceEncoder implements Finalizable {
 
   /// The output format to generate.
   ///
-  /// The default is [FLEncoderFormat.kFLEncodeFleece]
+  /// The default is [FLEncoderFormat.fleece]
   final FLEncoderFormat format;
 
   /// The number of bytes to preallocate for the output.

--- a/packages/cbl/lib/src/fleece/integration/delegate.dart
+++ b/packages/cbl/lib/src/fleece/integration/delegate.dart
@@ -56,23 +56,23 @@ final class SimpleMDelegate extends MDelegate {
 
     final flValue = globalLoadedFLValue.ref;
     switch (FLValueType.fromValue(flValue.type)) {
-      case FLValueType.kFLUndefined:
-      case FLValueType.kFLNull:
+      case FLValueType.undefined:
+      case FLValueType.null$:
         return null;
-      case FLValueType.kFLBoolean:
+      case FLValueType.boolean:
         return flValue.asBool;
-      case FLValueType.kFLNumber:
+      case FLValueType.number:
         return flValue.isInteger ? flValue.asInt : flValue.asDouble;
-      case FLValueType.kFLString:
+      case FLValueType.string:
         cacheIt();
         return parent.context.sharedStringsTable.decode(StringSource.value);
-      case FLValueType.kFLData:
+      case FLValueType.data:
         cacheIt();
         return flValue.asData.toData()?.toTypedList();
-      case FLValueType.kFLArray:
+      case FLValueType.array:
         cacheIt();
         return MArray.asChild(value, parent, flValue.collectionSize);
-      case FLValueType.kFLDict:
+      case FLValueType.dict:
         cacheIt();
         return MDict.asChild(value, parent, flValue.collectionSize);
     }

--- a/packages/cbl/lib/src/query/ffi_query.dart
+++ b/packages/cbl/lib/src/query/ffi_query.dart
@@ -170,7 +170,7 @@ base class FfiQuery extends QueryBase implements SyncQuery, Finalizable {
         ..endDict();
     }
     final data = encoder.finish();
-    final doc = fl.Doc.fromResultData(data, FLTrust.kFLTrusted);
+    final doc = fl.Doc.fromResultData(data, FLTrust.trusted);
     final dict = doc.root.asDict!;
     _bindings.setParameters(_pointer, dict.pointer.cast());
   }

--- a/packages/cbl/lib/src/query/index/index_builder.dart
+++ b/packages/cbl/lib/src/query/index/index_builder.dart
@@ -94,7 +94,7 @@ final class ValueIndexImpl implements IndexImplInterface, ValueIndex {
   @override
   CBLIndexSpec toCBLIndexSpec() => CBLIndexSpec(
         expressionLanguage: CBLQueryLanguage.json,
-        type: CBLDart_IndexType.kCBLDart_IndexTypeValue,
+        type: CBLDartIndexType.value$,
         expressions: _items
             .map((item) => item._expression.toJson())
             .toList()
@@ -132,7 +132,7 @@ final class FullTextIndexImpl implements IndexImplInterface, FullTextIndex {
   @override
   CBLIndexSpec toCBLIndexSpec() => CBLIndexSpec(
         expressionLanguage: CBLQueryLanguage.json,
-        type: CBLDart_IndexType.kCBLDart_IndexTypeFullText,
+        type: CBLDartIndexType.fullText,
         expressions: _items
             .map((item) => item._expression.toJson())
             .toList()

--- a/packages/cbl/lib/src/query/index/index_configuration.dart
+++ b/packages/cbl/lib/src/query/index/index_configuration.dart
@@ -344,7 +344,7 @@ final class _ValueIndexConfiguration extends _IndexConfiguration
   CBLIndexSpec toCBLIndexSpec() => CBLIndexSpec(
         expressionLanguage: CBLQueryLanguage.n1ql,
         expressions: expressions.join(', '),
-        type: CBLDart_IndexType.kCBLDart_IndexTypeValue,
+        type: CBLDartIndexType.value$,
       );
 
   @override
@@ -379,7 +379,7 @@ final class _FullTextIndexConfiguration extends _IndexConfiguration
   CBLIndexSpec toCBLIndexSpec() => CBLIndexSpec(
         expressionLanguage: CBLQueryLanguage.n1ql,
         expressions: expressions.join(', '),
-        type: CBLDart_IndexType.kCBLDart_IndexTypeFullText,
+        type: CBLDartIndexType.fullText,
         ignoreAccents: ignoreAccents,
         language: language?.name,
       );
@@ -528,7 +528,7 @@ final class _VectorIndexConfiguration extends _IndexConfiguration
     return CBLIndexSpec(
       expressionLanguage: CBLQueryLanguage.n1ql,
       expressions: expressions.join(', '),
-      type: CBLDart_IndexType.kCBLDart_IndexTypeVector,
+      type: CBLDartIndexType.vector,
       dimensions: dimensions,
       centroids: centroids,
       lazy: lazy,

--- a/packages/cbl/lib/src/query/index/proxy_index_updater.dart
+++ b/packages/cbl/lib/src/query/index/proxy_index_updater.dart
@@ -40,7 +40,7 @@ final class ProxyIndexUpdater extends ProxyObject
             data: switch (transferableValue) {
               TransferableValue(:final encodedData?) => fl.Doc.fromResultData(
                   encodedData.toFleece(),
-                  FLTrust.kFLTrusted,
+                  FLTrust.trusted,
                 ),
               TransferableValue(:final value) => value,
             },

--- a/packages/cbl/lib/src/query/prediction.dart
+++ b/packages/cbl/lib/src/query/prediction.dart
@@ -185,7 +185,7 @@ class _FfiPredictiveModel implements Finalizable {
       (outputDict as DictionaryImpl).encodeTo(encoder);
       final outputData = encoder.finish();
 
-      final outputDoc = fl.Doc.fromResultData(outputData, FLTrust.kFLTrusted);
+      final outputDoc = fl.Doc.fromResultData(outputData, FLTrust.trusted);
       final outputMutableDict =
           fl.MutableDict.mutableCopy(outputDoc.root.asDict!);
 

--- a/packages/cbl/lib/src/query/result.dart
+++ b/packages/cbl/lib/src/query/result.dart
@@ -293,7 +293,7 @@ final class ResultImpl with IterableMixin<String> implements Result {
 
   @override
   String toJson() {
-    final encoder = FleeceEncoder(format: FLEncoderFormat.kFLEncodeJSON);
+    final encoder = FleeceEncoder(format: FLEncoderFormat.json);
     final encodeResult = _dictionary.encodeTo(encoder);
     assert(encodeResult is! Future);
     final sliceResult = encoder.finish().toSliceResult();
@@ -314,7 +314,7 @@ final class ResultImpl with IterableMixin<String> implements Result {
       case EncodingFormat.json:
         if (columnValuesData != null) {
           columnValues =
-              fl.Doc.fromResultData(columnValuesData!, FLTrust.kFLTrusted).root
+              fl.Doc.fromResultData(columnValuesData!, FLTrust.trusted).root
                   as fl.Array;
         } else {
           columnValues = columnValuesArray!;
@@ -341,7 +341,7 @@ final class ResultImpl with IterableMixin<String> implements Result {
       root = MRoot.fromContext(
         DatabaseMContext.from(
           _context,
-          data: fl.Doc.fromResultData(columnValuesData!, FLTrust.kFLTrusted),
+          data: fl.Doc.fromResultData(columnValuesData!, FLTrust.trusted),
         ),
         isMutable: false,
       );

--- a/packages/cbl/lib/src/service/cbl_service_api.dart
+++ b/packages/cbl/lib/src/service/cbl_service_api.dart
@@ -332,10 +332,10 @@ SerializationRegistry cblServiceSerializationRegistry() =>
         serialize: (value, context) => value.index,
         deserialize: (value, context) => CBLQueryLanguage.values[value as int],
       )
-      ..addCodec<CBLDart_IndexType>(
-        'CBLIndexType',
+      ..addCodec<CBLDartIndexType>(
+        'CBLDartIndexType',
         serialize: (value, context) => value.index,
-        deserialize: (value, context) => CBLDart_IndexType.values[value as int],
+        deserialize: (value, context) => CBLDartIndexType.values[value as int],
       )
       ..addObjectCodec<CBLIndexSpec>(
         'CBLIndexSpec',

--- a/packages/cbl/lib/src/support/encoding.dart
+++ b/packages/cbl/lib/src/support/encoding.dart
@@ -11,14 +11,10 @@ enum EncodingFormat {
 }
 
 extension EncodingFormatExt on EncodingFormat {
-  FLEncoderFormat toFLEncoderFormat() {
-    switch (this) {
-      case EncodingFormat.fleece:
-        return FLEncoderFormat.kFLEncodeFleece;
-      case EncodingFormat.json:
-        return FLEncoderFormat.kFLEncodeJSON;
-    }
-  }
+  FLEncoderFormat toFLEncoderFormat() => switch (this) {
+        EncodingFormat.fleece => FLEncoderFormat.fleece,
+        EncodingFormat.json => FLEncoderFormat.json,
+      };
 }
 
 class EncodedData {
@@ -29,7 +25,7 @@ class EncodedData {
   EncodedData.json(this.data) : format = EncodingFormat.json;
 
   static final _jsonDecoder = const Utf8Decoder().fuse(const JsonDecoder());
-  static const _fleeceDecoder = FleeceDecoder(trust: FLTrust.kFLTrusted);
+  static const _fleeceDecoder = FleeceDecoder(trust: FLTrust.trusted);
 
   final EncodingFormat format;
 
@@ -47,8 +43,8 @@ class EncodedData {
   Data toJson() {
     switch (format) {
       case EncodingFormat.fleece:
-        final encoder = FleeceEncoder(format: FLEncoderFormat.kFLEncodeJSON);
-        final doc = Doc.fromResultData(data, FLTrust.kFLTrusted);
+        final encoder = FleeceEncoder(format: FLEncoderFormat.json);
+        final doc = Doc.fromResultData(data, FLTrust.trusted);
         final root = doc.root;
         encoder.writeValue(root.pointer);
         return encoder.finish();

--- a/packages/cbl_e2e_tests/lib/src/document/document_test_utils.dart
+++ b/packages/cbl_e2e_tests/lib/src/document/document_test_utils.dart
@@ -21,7 +21,7 @@ Array immutableArray([List<Object?>? data]) {
   array.encodeTo(encoder);
   final fleeceData = encoder.finish();
   final root = MRoot.fromContext(
-    createTestMContext(Doc.fromResultData(fleeceData, FLTrust.kFLTrusted)),
+    createTestMContext(Doc.fromResultData(fleeceData, FLTrust.trusted)),
     isMutable: false,
   );
   // ignore: cast_nullable_to_non_nullable
@@ -34,7 +34,7 @@ Dictionary immutableDictionary([Map<String, Object?>? data]) {
   array.encodeTo(encoder);
   final fleeceData = encoder.finish();
   final root = MRoot.fromContext(
-    createTestMContext(Doc.fromResultData(fleeceData, FLTrust.kFLTrusted)),
+    createTestMContext(Doc.fromResultData(fleeceData, FLTrust.trusted)),
     isMutable: false,
   );
   // ignore: cast_nullable_to_non_nullable

--- a/packages/cbl_e2e_tests/lib/src/fleece/coding_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/fleece/coding_test.dart
@@ -38,7 +38,7 @@ void main() {
         final sliceResult = data.toSliceResult();
         final sharedStringsTable = SharedStringsTable();
 
-        final flValue = _valueBinds.fromData(sliceResult, FLTrust.kFLTrusted)!;
+        final flValue = _valueBinds.fromData(sliceResult, FLTrust.trusted)!;
         for (var i = 0; i < 4; i++) {
           _decoderBinds.getLoadedValueFromArray(flValue.cast(), i);
           sharedStringsTable.decode(StringSource.value);
@@ -95,7 +95,7 @@ void main() {
 
       test('converts trusted Fleece data to Dart object', () {
         final encoder = FleeceEncoder();
-        final decoder = testFleeceDecoder(trust: FLTrust.kFLTrusted);
+        final decoder = testFleeceDecoder(trust: FLTrust.trusted);
         final data = encoder.convertJson('''
 [
   null, 41, 3.14, true, false, "a",

--- a/packages/cbl_e2e_tests/lib/src/fleece/containers_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/fleece/containers_test.dart
@@ -406,7 +406,7 @@ void main() {
         final doc = Doc.fromJson('{"a": "b"}');
         final dict = MutableDict.mutableCopy(
           doc.root.asDict!,
-          flags: FLCopyFlags.kFLDeepCopy,
+          flags: FLCopyFlags.deepCopy,
         );
         expect(dict.length, equals(1));
       });

--- a/packages/cbl_e2e_tests/lib/src/fleece/decoding_benchmark_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/fleece/decoding_benchmark_test.dart
@@ -44,7 +44,7 @@ class FleeceRecursiveDecodingBenchmark extends DecodingBenchmark {
   void run() {
     // ignore: deprecated_member_use
     RecursiveFleeceDecoder(
-      trust: FLTrust.kFLTrusted,
+      trust: FLTrust.trusted,
       sharedKeys: sharedKeys,
       sharedKeysTable: sharedKeysTable,
     ).convert(data);
@@ -62,7 +62,7 @@ class FleeceListenerDecodingBenchmark extends DecodingBenchmark {
   @override
   void run() {
     FleeceDecoder(
-      trust: FLTrust.kFLTrusted,
+      trust: FLTrust.trusted,
       sharedKeys: sharedKeys,
       sharedKeysTable: sharedKeysTable,
     ).convert(data);
@@ -81,7 +81,7 @@ class FleeceWrapperDecodingBenchmark extends DecodingBenchmark {
   @override
   void run() {
     final doc =
-        fl.Doc.fromResultData(data, FLTrust.kFLTrusted, sharedKeys: sharedKeys);
+        fl.Doc.fromResultData(data, FLTrust.trusted, sharedKeys: sharedKeys);
     final root = MRoot.fromContext(
       MContext(
         data: doc,

--- a/packages/cbl_e2e_tests/lib/src/fleece/integration_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/fleece/integration_test.dart
@@ -290,7 +290,7 @@ void main() {
 
 MRoot testMRoot(Object from) => MRoot.fromContext(
       MContext(
-        data: Doc.fromResultData(fleeceEncode(from), FLTrust.kFLTrusted),
+        data: Doc.fromResultData(fleeceEncode(from), FLTrust.trusted),
       ),
       isMutable: true,
     );

--- a/packages/cbl_e2e_tests/lib/src/utils/fleece_coding.dart
+++ b/packages/cbl_e2e_tests/lib/src/utils/fleece_coding.dart
@@ -17,5 +17,5 @@ Data fleeceEncode(Object? value) {
 
 Object? fleeceDecode(Data data) => testFleeceDecoder().convert(data);
 
-FleeceDecoder testFleeceDecoder({FLTrust trust = FLTrust.kFLUntrusted}) =>
+FleeceDecoder testFleeceDecoder({FLTrust trust = FLTrust.untrusted}) =>
     FleeceDecoder(trust: trust);


### PR DESCRIPTION
Disable comments

Use ints for enums