### PR TITLE
fix: ensure `copyDirectoryContents` can overwrite links on all platforms

### DIFF
--- a/packages/cbl/lib/src/install/utils.dart
+++ b/packages/cbl/lib/src/install/utils.dart
@@ -156,7 +156,13 @@ Future<void> copyDirectoryContents(
         await File(destPath).create(recursive: true);
         await File(entity.resolveSymbolicLinksSync()).copy(destPath);
       } else {
-        await Link(destPath).create(await entity.target());
+        try {
+          await Link(destPath).create(await entity.target());
+        } on PathExistsException {
+          // Links can't be overwritten on some platforms.
+          await Link(destPath).delete();
+          await Link(destPath).create(await entity.target());
+        }
       }
     } else if (entity is File) {
       await entity.copy(destPath);

--- a/packages/cbl/test/install/package_test.dart
+++ b/packages/cbl/test/install/package_test.dart
@@ -3,12 +3,12 @@ import 'dart:io';
 import 'package:cbl/src/install/package.dart';
 import 'package:test/test.dart';
 
+import '../utils.dart';
+
 void main() {
   group('DatabasePackageConfig', () {
     test('download packages ', () async {
-      final tempCacheDir = Directory.systemTemp.createTempSync();
-      addTearDown(() => tempCacheDir.deleteSync(recursive: true));
-
+      final tempCacheDir = tempTestDirectory();
       final loader = RemotePackageLoader(cacheDir: tempCacheDir.path);
       final configs = [
         for (final edition in Edition.values)
@@ -23,9 +23,7 @@ void main() {
 
   group('VectorSearchPackageConfig', () {
     test('download packages', () async {
-      final tempCacheDir = Directory.systemTemp.createTempSync();
-      addTearDown(() => tempCacheDir.deleteSync(recursive: true));
-
+      final tempCacheDir = tempTestDirectory();
       final loader = RemotePackageLoader(cacheDir: tempCacheDir.path);
       final packageConfigs = VectorSearchPackageConfig.all(release: '1.0.0')
           .withoutMacOSonDifferentHost;

--- a/packages/cbl/test/install/utils_test.dart
+++ b/packages/cbl/test/install/utils_test.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:cbl/src/install.dart';
+import 'package:test/test.dart';
+
+import '../utils.dart';
+
+void main() {
+  group('copyDirectoryContents', () {
+    test('override link', () async {
+      final sourceDir = tempTestDirectory();
+      final targetDir = tempTestDirectory();
+
+      File('${sourceDir.path}/file').writeAsStringSync('content');
+      Link('${sourceDir.path}/link').createSync('file');
+
+      await copyDirectoryContents(sourceDir.path, targetDir.path);
+      expect(File('${targetDir.path}/file').readAsStringSync(), 'content');
+      expect(Link('${targetDir.path}/link').targetSync(), 'file');
+
+      await copyDirectoryContents(sourceDir.path, targetDir.path);
+      expect(File('${targetDir.path}/file').readAsStringSync(), 'content');
+      expect(Link('${targetDir.path}/link').targetSync(), 'file');
+    });
+  });
+}

--- a/packages/cbl/test/utils.dart
+++ b/packages/cbl/test/utils.dart
@@ -1,0 +1,9 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+Directory tempTestDirectory() {
+  final directory = Directory.systemTemp.createTempSync();
+  addTearDown(() => directory.deleteSync(recursive: true));
+  return directory;
+}


### PR DESCRIPTION
Fixes #719