### PR TITLE
fix: memory leak in `ObjectRegistry`

### DIFF
--- a/packages/cbl/lib/src/service/object_registry.dart
+++ b/packages/cbl/lib/src/service/object_registry.dart
@@ -42,6 +42,7 @@ final class ObjectRegistry {
       throw ArgumentError.value(object, 'object', 'is not registered');
     }
 
+    _objectToId.remove(object);
     _idToObject.remove(id);
   }
 
@@ -57,6 +58,7 @@ final class ObjectRegistry {
     }
 
     _objectToId.remove(object);
+    _idToObject.remove(id);
     return object;
   }
 


### PR DESCRIPTION
`ObjectRegistry` has a mapping from `Object` to `int` and from `int` to `Object`, but removing an object from the registry only removed in from one of the mappings.