### PR TITLE
refactor: consistently use `getObjectOrThrow` to find objects in `ObjectRegistry`

### DIFF
--- a/packages/cbl/lib/src/service/cbl_service_api.dart
+++ b/packages/cbl/lib/src/service/cbl_service_api.dart
@@ -2634,7 +2634,7 @@ final class DocumentReplicationEvent extends Serializable {
 
 final class NotFoundException extends Serializable implements Exception {
   NotFoundException(this.id, this.type)
-      : message = 'Could not find object of type $type with id $id';
+      : message = 'Could not find $type with id $id';
 
   final String message;
   final String type;

--- a/packages/cbl/lib/src/support/listener_token.dart
+++ b/packages/cbl/lib/src/support/listener_token.dart
@@ -76,7 +76,7 @@ class ListenerTokenRegistry with ClosableResourceMixin {
   @override
   Future<void> performClose() async {
     await Future.wait<void>(
-      _tokens.map((token) => Future.value(token.removeListener())),
+      _tokens.map((token) async => token.removeListener()),
     );
     _tokens.clear();
   }

--- a/packages/cbl_e2e_tests/lib/src/service/cbl_service_api_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/service/cbl_service_api_test.dart
@@ -81,7 +81,7 @@ void main() {
       expect(result.type, 'a');
       expect(
         result.toString(),
-        'NotFound: Could not find object of type a with id 0',
+        'NotFound: Could not find a with id 0',
       );
     });
   });


### PR DESCRIPTION
Also, improve `NotFoundException.message` slightly.