### PR TITLE
Upgrading cbl dependencies

### DIFF
--- a/packages/cbl/pubspec.yaml
+++ b/packages/cbl/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'cbl'
-version: 3.4.2
+version: 3.4.3
 description: >-
   Couchbase Lite is an embedded, NoSQL JSON Document Style database, supporting
   Blobs, Encryption, SQL++ Queries, Live Queries, Full-Text Search and Data
@@ -12,19 +12,19 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
-  archive: ^3.6.1
-  cbl_libcblite_api: ^3.1.3
+  archive: ^4.0.4
+  cbl_libcblite_api: ^3.2.0
   cbl_libcblitedart_api: ^8.1.1
-  characters: ^1.1.0
-  collection: ^1.15.0
-  ffi: ^2.0.1
-  http: ^1.2.2
-  meta: ^1.3.0
-  path: ^1.8.0
-  stream_channel: ^2.1.0
-  synchronized: ^3.0.0
-  web_socket_channel: '>=2.1.0 <4.0.0'
+  characters: ^1.4.0
+  collection: ^1.19.1
+  ffi: ^2.1.4
+  http: ^1.3.0
+  meta: ^1.16.0
+  path: ^1.9.1
+  stream_channel: ^2.1.4
+  synchronized: ^3.3.1
+  web_socket_channel: ^3.0.2
 
 dev_dependencies:
-  ffigen: ^16.0.0
-  test: ^1.21.1
+  ffigen: ^18.0.0
+  test: ^1.25.15


### PR DESCRIPTION
To fix this:

```
Because no versions of flutter_native_splash match >2.4.5 <3.0.0 and flutter_native_splash 2.4.5 depends on image ^4.5.2, flutter_native_splash ^2.4.5 requires image ^4.5.2.
And because image >=4.5.2 depends on archive ^4.0.2, flutter_native_splash ^2.4.5 requires archive ^4.0.2.

And because cbl_flutter >=3.3.1 depends on cbl ^3.4.1 which depends on archive ^3.6.1, flutter_native_splash ^2.4.5 is incompatible with cbl_flutter >=3.3.1.
So, because circulos depends on both cbl_flutter ^3.3.1 and flutter_native_splash ^2.4.5, version solving failed.
```