### PR TITLE
chore: fix dylib glob patterns in dev-tools script

### DIFF
--- a/tools/dev-tools.sh
+++ b/tools/dev-tools.sh
@@ -155,8 +155,8 @@ function prepareNativeLibraries() {
         rm -rf "$cblFlutterLocalMacosLibrariesDir"
         mkdir -p "$cblFlutterLocalMacosLibrariesDir"
         mkdir -p "$cblFlutterLocalMacosFrameworksDir"
-        cp -L "$couchbaseLiteCArchiveDir/libcblite-"*"/lib/libcblite."?".dylib" "$cblFlutterLocalMacosLibrariesDir"
-        cp -L "$couchbaseLiteDartBuildDir/unix/libcblitedart-"*"/lib/libcblitedart."?".dylib" "$cblFlutterLocalMacosLibrariesDir"
+        cp -L "$couchbaseLiteCArchiveDir/libcblite-"*"/lib/libcblite."*".dylib" "$cblFlutterLocalMacosLibrariesDir"
+        cp -L "$couchbaseLiteDartBuildDir/unix/libcblitedart-"*"/lib/libcblitedart."*".dylib" "$cblFlutterLocalMacosLibrariesDir"
         cp -a "$couchbaseLiteVectorSearchArchiveDir/"* "$cblFlutterLocalMacosFrameworksDir"
         ;;
     linux-x86_64)


### PR DESCRIPTION
## Summary
- Fixed glob patterns in `tools/dev-tools.sh` from `?.dylib` to `*.dylib`
- Resolves issue where files like `libcblite.11.dylib` and `libcblitedart.11.0.0.dylib` weren't being matched
- The single character wildcard `?` was too restrictive for multi-digit version numbers

## Test plan
- [ ] Verify that `prepareNativeLibraries()` function now correctly copies dylib files with version suffixes
- [ ] Test macOS build process to ensure native libraries are properly included

🤖 Generated with [Claude Code](https://claude.ai/code)