### PR TITLE
fix: restore CI compatibility with Flutter 3.47

### DIFF
--- a/all_lint_rules.yaml
+++ b/all_lint_rules.yaml
@@ -110,7 +110,7 @@ linter:
     - null_closures
     - omit_local_variable_types
     - omit_obvious_local_variable_types
-    - omit_obvious_property_types
+    # - omit_obvious_property_types # conflicts with type_annotate_public_apis
     - one_member_abstracts
     - only_throw_errors
     - overridden_fields

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,6 +3,13 @@ include: all_lint_rules.yaml
 analyzer:
   exclude:
     - node_modules/**
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   language:
     strict-casts: true
     strict-inference: true

--- a/packages/cbl_e2e_tests/analysis_options.yaml
+++ b/packages/cbl_e2e_tests/analysis_options.yaml
@@ -3,6 +3,14 @@ include: ../../analysis_options.yaml
 analyzer:
   errors:
     experimental_member_use: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/packages/cbl_e2e_tests/lib/src/tracing_test.dart
+++ b/packages/cbl_e2e_tests/lib/src/tracing_test.dart
@@ -111,7 +111,6 @@ void main() {
 }
 
 final class TestDelegate extends TracingDelegate {
-  // ignore: omit_obvious_property_types
   TestWorkerDelegate workerDelegate = TestWorkerDelegate();
 
   @override

--- a/packages/cbl_e2e_tests/lib/src/utils/test_variant.dart
+++ b/packages/cbl_e2e_tests/lib/src/utils/test_variant.dart
@@ -43,8 +43,8 @@ final class EnumVariant<T extends Enum> extends TestVariant<T> {
   EnumVariant(
     List<T> values, {
     String? name,
-    VariantIsCompatible<T>? isCompatible,
-    int order = 0,
+    super.isCompatible,
+    super.order = 0,
   }) : assert(values.isNotEmpty),
        super(
          name ??
@@ -53,8 +53,6 @@ final class EnumVariant<T extends Enum> extends TestVariant<T> {
                (match) => match.group(0)!.toLowerCase(),
              ),
          values: values,
-         isCompatible: isCompatible,
-         order: order,
        );
 
   @override

--- a/packages/cbl_e2e_tests_flutter/analysis_options.yaml
+++ b/packages/cbl_e2e_tests_flutter/analysis_options.yaml
@@ -3,3 +3,11 @@ include: ../../analysis_options.yaml
 analyzer:
   errors:
     experimental_member_use: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/cbl_e2e_tests_standalone_dart/analysis_options.yaml
+++ b/packages/cbl_e2e_tests_standalone_dart/analysis_options.yaml
@@ -3,3 +3,11 @@ include: ../../analysis_options.yaml
 analyzer:
   errors:
     experimental_member_use: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/cbl_generator/analysis_options.yaml
+++ b/packages/cbl_generator/analysis_options.yaml
@@ -3,3 +3,11 @@ include: ../../analysis_options.yaml
 analyzer:
   errors:
     experimental_member_use: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/packages/cbl_generator/lib/src/analysis.dart
+++ b/packages/cbl_generator/lib/src/analysis.dart
@@ -24,7 +24,6 @@ final class _ClassHasRedirectingUnnamedConstructorVisitor
 
   final String targetConstructor;
 
-  // ignore: omit_obvious_property_types
   bool hasRedirectingConstructor = false;
 
   @override
@@ -49,7 +48,6 @@ final class _ClassHasMixinVisitor extends RecursiveAstVisitor<void> {
 
   final String mixinName;
 
-  // ignore: omit_obvious_property_types
   bool hasMixin = false;
 
   @override

--- a/packages/cbl_generator/lib/src/builder.dart
+++ b/packages/cbl_generator/lib/src/builder.dart
@@ -1,16 +1,14 @@
-import 'package:build/build.dart';
 import 'package:meta/meta.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'generator.dart';
 
 final class TypedDataBuilder extends PartBuilder {
-  TypedDataBuilder({BuilderOptions? options})
+  TypedDataBuilder({super.options})
     : super(
         [TypedDocumentGenerator(), TypedDictionaryGenerator()],
         '.cbl.type.g.dart',
         header: header,
-        options: options,
       );
 
   static const _ignoredLints = [
@@ -32,12 +30,11 @@ final class TypedDataBuilder extends PartBuilder {
 }
 
 final class TypedDatabaseBuilder extends LibraryBuilder {
-  TypedDatabaseBuilder({BuilderOptions? options})
+  TypedDatabaseBuilder({super.options})
     : super(
         TypedDatabaseGenerator(),
         generatedExtension: '.cbl.database.g.dart',
         header: header,
-        options: options,
       );
 
   static const _ignoredLints = [

--- a/packages/cbl_sentry/test/utils/mock_span.dart
+++ b/packages/cbl_sentry/test/utils/mock_span.dart
@@ -13,7 +13,6 @@ class MockSpan implements ISentrySpan {
   final SpanId? transactionParentSpanId;
 
   @override
-  // ignore: omit_obvious_property_types
   bool finished = false;
 
   final String operation;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -454,10 +454,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -843,26 +843,26 @@ packages:
     dependency: "direct overridden"
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.31.1"
   test_api:
     dependency: "direct overridden"
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   test_core:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.18"
   typed_data:
     dependency: transitive
     description:
@@ -883,10 +883,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -976,5 +976,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
+  dart: ">=3.11.0-0 <4.0.0"
   flutter: ">=3.38.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,9 +35,8 @@ dependency_overrides:
   # Keep the entire workspace on that test runner so the standalone sanitizer
   # CI leg can resolve compatible dependencies without carving Flutter out of
   # the workspace.
-  test: 1.31.0
-  test_api: 0.7.11
-  test_core: 0.6.17
+  test: ^1.31.1
+  test_api: 0.7.12
 
 melos:
   repository: https://github.com/cbl-dart/cbl-dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,7 +69,9 @@ melos:
 
     test:unit:
       description: Runs unit tests (non-e2e).
-      exec: dart test
+      run: dart test
+      exec:
+        concurrency: 1
       packageFilters:
         scope:
           - cbl

--- a/tool/lib/src/github_actions.dart
+++ b/tool/lib/src/github_actions.dart
@@ -84,11 +84,8 @@ final class JobStats {
   JobStats({required this.name});
 
   final String name;
-  // ignore: omit_obvious_property_types
   int totalRuns = 0;
-  // ignore: omit_obvious_property_types
   int successes = 0;
-  // ignore: omit_obvious_property_types
   int failures = 0;
   final recentFailures = <JobFailure>[];
 

--- a/tools/ci-steps.sh
+++ b/tools/ci-steps.sh
@@ -144,35 +144,19 @@ function _prepareStandaloneSanitizerNativeAssets() {
 
     # `dart test -p vm-asan` compiles test suites to native executables, but
     # that execution path does not currently wire native (code) assets into the
-    # generated process. The build hooks still materialize the native libraries
-    # when a test suite is built, so build them here and preload them to satisfy
-    # `@Native`/`@ffi.DefaultAsset`'s fallback to process symbol lookup.
-    #
-    # Building the native assets requires actually compiling a test suite;
-    # `dart test --help` no longer triggers the build hooks. Compile the
-    # placeholder empty test to run the build hooks without running the real
-    # suite. It exits non-zero because the file contains no tests, so ignore its
-    # exit status — a genuine build failure surfaces below when no libraries are
-    # found.
-    dart test test/empty_test.dart >/dev/null 2>&1 || true
+    # generated process. Build a CLI bundle for the placeholder test so that
+    # the build and link hooks copy the native libraries to a stable output
+    # directory. A regular `dart test` build only keeps them in an internal
+    # hooks_runner cache in recent Dart SDKs.
+    local nativeAssetsOutput="$PWD/.dart_tool/standalone_sanitizer_native_assets"
+    dart build cli \
+        --target=test/empty_test.dart \
+        --output="$nativeAssetsOutput"
 
-    # With pub workspaces, recent Dart SDKs create the flat native-asset `lib`
-    # directory at the workspace root rather than in the package directory.
-    # Probe both locations and use the first that contains the libraries so the
-    # step keeps working regardless of which layout the SDK uses.
-    local nativeLibDir=""
-    local candidate
-    for candidate in "$workspaceDir/.dart_tool/lib" "$PWD/.dart_tool/lib"; do
-        if find "$candidate" -maxdepth 1 -type f -name 'libcblitedart.so*' \
-            2>/dev/null | grep -q .; then
-            nativeLibDir="$candidate"
-            break
-        fi
-    done
-
-    if [ -z "$nativeLibDir" ]; then
-        echo "No native libraries found to preload in" \
-            "$workspaceDir/.dart_tool/lib or $PWD/.dart_tool/lib"
+    local nativeLibDir="$nativeAssetsOutput/bundle/lib"
+    if ! find "$nativeLibDir" -maxdepth 1 -type f -name 'libcblitedart.so*' \
+        2>/dev/null | grep -q .; then
+        echo "No native libraries found to preload in $nativeLibDir"
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

- update the test runner overrides for Flutter 3.47 dependency pins
- let test select the matching test_core version transitively
- update SDK-triggered lint configuration and super-parameter usages

## Testing

- Flutter 3.47 dependency resolution
- dart analyze --fatal-infos
- formatting check
- cbl, cbl_generator, and cbl_sentry unit tests

The full quality-gates retry hit a local native-library code-signing race while packages ran in parallel. Re-running the affected cbl test suite on its own passed.